### PR TITLE
:bug: 추천피드 요청시 마다 링크가 복사되는 버그 해결

### DIFF
--- a/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
@@ -25,7 +25,7 @@ public class RecommendFeedService {
 
     private final FeedService feedService;
 
-    private List<Feed> recommendFeeds2 = List.of();
+    private List<Feed> recommendFeeds = List.of();
 
     private final static int DEFAULT_PAGE_SIZE = 1000;
     private final static Pageable DEFAULT_PAGEABLE = PageRequest.of(0, DEFAULT_PAGE_SIZE);
@@ -33,7 +33,7 @@ public class RecommendFeedService {
 
 
     public CollectionModel<FeedPreviewDto> getRecommendFeeds() {
-        return CollectionModel.of(recommendFeeds2.stream()
+        return CollectionModel.of(recommendFeeds.stream()
                 .map(FeedPreviewDto::from)
                 .collect(Collectors.toList()));
     }
@@ -55,7 +55,7 @@ public class RecommendFeedService {
             page = feedService.findForUpdatingRecommend(from, to, p);
         }
 
-        recommendFeeds2 = queue.getList();
+        recommendFeeds = queue.getList();
     }
 
     public void setPageSize(int pageSize) {

--- a/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
@@ -25,7 +25,7 @@ public class RecommendFeedService {
 
     private final FeedService feedService;
 
-    private CollectionModel<FeedPreviewDto> recommendFeeds = CollectionModel.of(List.of());
+    private List<Feed> recommendFeeds2 = List.of();
 
     private final static int DEFAULT_PAGE_SIZE = 1000;
     private final static Pageable DEFAULT_PAGEABLE = PageRequest.of(0, DEFAULT_PAGE_SIZE);
@@ -33,7 +33,9 @@ public class RecommendFeedService {
 
 
     public CollectionModel<FeedPreviewDto> getRecommendFeeds() {
-        return recommendFeeds;
+        return CollectionModel.of(recommendFeeds2.stream()
+                .map(FeedPreviewDto::from)
+                .collect(Collectors.toList()));
     }
 
     @PostConstruct
@@ -53,9 +55,7 @@ public class RecommendFeedService {
             page = feedService.findForUpdatingRecommend(from, to, p);
         }
 
-        recommendFeeds = CollectionModel.of(queue.getList().stream()
-                .map(FeedPreviewDto::from)
-                .collect(Collectors.toList()));
+        recommendFeeds2 = queue.getList();
     }
 
     public void setPageSize(int pageSize) {

--- a/src/main/java/container/restaurant/server/web/FeedController.java
+++ b/src/main/java/container/restaurant/server/web/FeedController.java
@@ -119,6 +119,7 @@ public class FeedController {
                                 Category::getKorean)));
     }
 
+    // TODO Linker 모듈에 setLinks 자체의 책임을 주는 방법을 고민해보자
     private FeedDetailDto setLinks(FeedDetailDto dto, Long loginId) {
         boolean isOwner = dto.getOwnerId().equals(loginId);
         return dto


### PR DESCRIPTION
원인: RecommendFeedService 에서 RepresentationModel 을 가지고있어서, Controller 에 넘겨줄 때 마다 링크가 추가됨

조치: RecommendFeedService 에서 List<Feed> 를 가지고, 필요할 떄 마다 변환하도록 수정

TODO: setLinks() 함수에 대한 책임도 컨트롤러가 아닌 Linker 가 할 수 있도록 개선하면 좋을 것 같다.