### PR TITLE
:sparkles: 내 정보 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -136,6 +136,14 @@ OAuth 2.0 제공자에 아래 리다이렉트 URI 를 등록하여 로그인 및
 
 operation::get-user[snippets='curl-request,http-response,response-fields,links']
 
+[[my-info]]
+=== 내 정보 조회
+`GET /api/user`
+
+operation::my-info[snippets='curl-request,http-response']
+
+내 정보 조회시 응답 형식은 <<user-get>>를 참조합니다.
+
 [[user-update]]
 === 사용자 정보 변경
 `PATCH /api/user/[유저_ID]`

--- a/src/main/java/container/restaurant/server/config/auth/LoginUserFilter.java
+++ b/src/main/java/container/restaurant/server/config/auth/LoginUserFilter.java
@@ -1,0 +1,30 @@
+package container.restaurant.server.config.auth;
+
+import container.restaurant.server.config.auth.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static java.util.Optional.ofNullable;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserFilter implements Filter {
+
+    private final HttpSession httpSession;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        ofNullable(httpSession.getAttribute("user"))
+                .ifPresent(object -> {
+                    SessionUser user = (SessionUser) object;
+                    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+                    httpServletResponse.setHeader("Container-Restaurant-User-Id", user.getId().toString());
+                });
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/container/restaurant/server/web/IndexController.java
+++ b/src/main/java/container/restaurant/server/web/IndexController.java
@@ -63,12 +63,11 @@ public class IndexController {
                         indexLinker.getBanners().withRel("banner-list")
                 ))
                 .addAllIf(loginId == null, () -> List.of(
-                        Link.of("/login").withRel("login"),
-                        Link.of("/login").withRel("my-info")
+                        Link.of("/login").withRel("login")
                 ))
                 .addAllIf(loginId != null, () -> List.of(
                         Link.of("/logout").withRel("logout"),
-                        userLinker.getUserById(loginId).withRel("my-info")
+                        userLinker.getCurrentUser().withRel("my-info")
                 ));
     }
 

--- a/src/main/java/container/restaurant/server/web/UserController.java
+++ b/src/main/java/container/restaurant/server/web/UserController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpSession;
 import java.util.List;
 
+import static java.util.Optional.ofNullable;
+
 @RequiredArgsConstructor
 @RestController
 @Validated
@@ -30,6 +32,13 @@ public class UserController {
     private final UserLinker userLinker;
     private final FeedLinker feedLinker;
     private final RestaurantFavoriteLinker restaurantFavoriteLinker;
+
+    @GetMapping
+    public ResponseEntity<?> getCurrentUser(@LoginUser SessionUser sessionUser) {
+        return ResponseEntity.of(ofNullable(sessionUser)
+                .map(SessionUser::getId)
+                .map(id -> setLinks(userService.getUserInfoById(id), id)));
+    }
 
     @GetMapping("{id}")
     public ResponseEntity<?> getUserById(

--- a/src/main/java/container/restaurant/server/web/linker/UserLinker.java
+++ b/src/main/java/container/restaurant/server/web/linker/UserLinker.java
@@ -40,4 +40,8 @@ public class UserLinker {
     public LinkBuilder existsNickname() {
         return existsNickname(null);
     }
+
+    public LinkBuilder getCurrentUser() {
+        return linkTo(proxy.getCurrentUser(u));
+    }
 }

--- a/src/test/java/container/restaurant/server/web/IndexControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/IndexControllerTest.java
@@ -36,7 +36,6 @@ class IndexControllerTest extends BaseUserControllerTest {
                                 linkWithRel("top-users").description("누적 피드가 최근 30일간 제일 많은 10명에 대한 리스트 링크"),
                                 linkWithRel("recent-users").description("최근에 피드를 작성한 사용자 리스트 링크"),
                                 linkWithRel("banner-list").description("배너 리스트 링크"),
-                                linkWithRel("my-info").description("사용자 상세 정보 링크 (비로그인인 경우 로그인 링크)"),
                                 linkWithRel("login").description("인증을 위한 링크 리스트")
                         )
         ));

--- a/src/test/java/container/restaurant/server/web/UserControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/UserControllerTest.java
@@ -287,4 +287,29 @@ class UserControllerTest extends BaseUserControllerTest {
                                         "1~10자의 한글이나 2~20자의 영문/숫자/공백만 입력 가능합니다."));
     }
 
+    @Test
+    @DisplayName("현재 사용자 정보")
+    void getUserId() throws Exception {
+        mvc.perform(
+                get("/api/user")
+                        .session(myselfSession))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("id").value(myself.getId()))
+                .andExpect(jsonPath("email").value(myself.getEmail()))
+                .andExpect(jsonPath("nickname").value(myself.getNickname()))
+                .andExpect(jsonPath("profile").value(myself.getProfile()))
+                .andExpect(jsonPath("level").value(myself.getLevel()))
+                .andExpect(jsonPath("feedCount").value(myself.getFeedCount()))
+                .andExpect(jsonPath("scrapCount").value(myself.getScrapCount()))
+                .andExpect(jsonPath("bookmarkedCount").value(myself.getBookmarkedCount()))
+                .andExpect(jsonPath("_links.self.href").exists())
+                .andExpect(jsonPath("_links.feeds.href").exists())
+                .andExpect(jsonPath("_links.patch.href").exists())
+                .andExpect(jsonPath("_links.delete.href").exists())
+                .andExpect(jsonPath("_links.nickname-exists.href").exists())
+                .andExpect(jsonPath("_links.scraps.href").exists())
+                .andDo(document("my-info"));
+    }
+
+
 }


### PR DESCRIPTION
:sparkles: 내 정보 조회 기능 추가
:memo: 내 정보 조회 Docs 추가
:art: 홈에서 my-info 링크를 내 정보 조회로 변경하고, 비로그인 시 my-info 삭제

(ID 만내려주는거보다 리소스 자체를 내려주는게 더 RESTful 하다고 생각돼서 아래와 같이 구현했습니다.

+ 로그인 되어있는 경우 모든 응답 헤더에 `Container-Restaurant-User-Id` 속성이 포함되며, 이는 로그인한 사용자의 ID 를 의미합니다.