### PR TITLE
:art: 근처 식당 검색 정렬 추가

### DIFF
--- a/src/main/java/container/restaurant/server/domain/restaurant/RestaurantRepository.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/RestaurantRepository.java
@@ -16,9 +16,10 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // TODO Thumbnail 과 조인
     @Query(nativeQuery = true,
-            value = "SELECT *, ST_DISTANCE_SPHERE(POINT(?2, ?1), POINT(longitude,latitude)) AS dist\n" +
-                    "FROM tb_restaurant FORCE INDEX FOR JOIN (`restaurant-loc-index`)\n" +
-                    "WHERE MBRCONTAINS(ST_LINESTRINGFROMTEXT( getDiagonal(?1,?2,?3)), location)")
+            value = "SELECT *, ST_DISTANCE_SPHERE(POINT(?2, ?1), POINT(longitude,latitude)) AS dist " +
+                    "FROM tb_restaurant FORCE INDEX FOR JOIN (`restaurant-loc-index`) " +
+                    "WHERE MBRCONTAINS(ST_LINESTRINGFROMTEXT( getDiagonal(?1,?2,?3)), location) " +
+                    "ORDER BY dist")
     List<Restaurant> findNearByRestaurants(double lat, double lon, long radius);
 
     Optional<Restaurant> findByName(String name);


### PR DESCRIPTION
기존 사용자 주변 식당 검색에 order by dist 추가 하여 가까운 순서로 반환되게 수정

사유 : 주변 식당 재검색 시 20km 내 가장 가까운 식당을 조회해야 되는 부분 발생
