### PR TITLE
🐛 추천 피드가 뜨지 않는 현상 해결

### DIFF
--- a/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
@@ -43,7 +43,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query("select f from TB_FEED f join f.scrapedBy s join f.owner left join f.thumbnail where s.user.id = ?1 and f.category = ?2")
     Page<Feed> findAllByScraperIdAndCategory(Long userId, Pageable pageable, Category category);
 
-    @EntityGraph(attributePaths = { "owner", "thumbnail" })
+    @EntityGraph(attributePaths = { "owner", "thumbnail", "restaurant" })
     Page<Feed> findAllByCreatedDateBetweenOrderByCreatedDateDesc(LocalDateTime from, LocalDateTime to, Pageable pageable);
 
 }

--- a/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/recommend/RecommendFeedService.java
@@ -16,7 +16,6 @@ import javax.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -25,7 +24,7 @@ public class RecommendFeedService {
 
     private final FeedService feedService;
 
-    private List<Feed> recommendFeeds = List.of();
+    private CollectionModel<FeedPreviewDto> recommends;
 
     private final static int DEFAULT_PAGE_SIZE = 1000;
     private final static Pageable DEFAULT_PAGEABLE = PageRequest.of(0, DEFAULT_PAGE_SIZE);
@@ -33,9 +32,7 @@ public class RecommendFeedService {
 
 
     public CollectionModel<FeedPreviewDto> getRecommendFeeds() {
-        return CollectionModel.of(recommendFeeds.stream()
-                .map(FeedPreviewDto::from)
-                .collect(Collectors.toList()));
+        return recommends;
     }
 
     @PostConstruct
@@ -54,8 +51,9 @@ public class RecommendFeedService {
             p = p.next();
             page = feedService.findForUpdatingRecommend(from, to, p);
         }
-
-        recommendFeeds = queue.getList();
+        recommends = CollectionModel.of(queue.getList().stream()
+                .map(FeedPreviewDto::from)
+                .collect(Collectors.toList()));
     }
 
     public void setPageSize(int pageSize) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,9 @@ spring.servlet.multipart.maxFileSize=10MB
 spring.servlet.multipart.maxRequestSize=10MB
 spring.session.store-type=jdbc
 spring.session.jdbc.initialize-schema=always
+
+### SQL 위치 관련 정보 Serialize 하기위한 데이터 베이스 추가설정 ##
+# MySQL 설정
+# spring.jpa.database-platform = org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect
+# H2 설정
+# spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.h2geodb.GeoDBDialect


### PR DESCRIPTION
### 원인
- `RecommendFeedService` 에 `Restaurant` 가 로딩되지 않은 `Feed` 엔티티가 준영속 상태가 된 이후 `Restaurant` 지연로딩을 실행하면서 에러가 발생

### 해결
- `RecommendFeedService` 에서 `Feed` 준영속 엔티티가 아닌 `FeedPreviewDto` 를 들고있도록 수정하여 위 동작이 발생하지 않도록 회피

### 추가사항
- 추천 피드 생성 시 전체 피드를 순회 조회할 때 식당에 대해 1 + N 문제가 발생하지 않도록 추가 수정
- 식당 위치 관련하여 Deserialize 에러가 발생하는 경우를 대비해 `application.properties` 에 주석으로 설정 추가

Closes #109 