### PR TITLE
:sparkles: 식당 대표 이미지 적용 추가

### DIFF
--- a/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
@@ -46,4 +46,6 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @EntityGraph(attributePaths = { "owner", "thumbnail", "restaurant" })
     Page<Feed> findAllByCreatedDateBetweenOrderByCreatedDateDesc(LocalDateTime from, LocalDateTime to, Pageable pageable);
 
+    @EntityGraph(attributePaths = { "thumbnail", "restaurant"})
+    Feed findFirstByRestaurantIdAndThumbnailIdIsNotNullOrderByLikeCountDesc(Long restaurantId);
 }

--- a/src/main/java/container/restaurant/server/domain/feed/FeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedService.java
@@ -141,9 +141,8 @@ public class FeedService {
         User user = userService.findById(ownerId);
         Restaurant restaurant = restaurantService.findByDto(dto.getRestaurantCreateDto());
         Image thumbnail = imageService.findById(dto.getThumbnailImageId());
-
         Feed feed = feedRepository.save(dto.toFeedWith(user, restaurant, thumbnail));
-
+        restaurant.setThumbnail(findRestaurantRepFeedThumbnail(restaurant));
         statisticsService.addRecentUser(user);
 
         feed.getOwner().feedCountUp();
@@ -213,5 +212,11 @@ public class FeedService {
                 .isLike(feedLikeRepository.existsByUserIdAndFeedId(loginId, feed.getId()))
                 .isScraped(scrapFeedRepository.existsByUserIdAndFeedId(loginId, feed.getId()))
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Image findRestaurantRepFeedThumbnail(Restaurant restaurant) {
+        Feed repFeed = feedRepository.findFirstByRestaurantIdAndThumbnailIdIsNotNullOrderByLikeCountDesc(restaurant.getId());
+        return repFeed.getThumbnail();
     }
 }

--- a/src/main/java/container/restaurant/server/domain/feed/picture/ImageService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/picture/ImageService.java
@@ -38,11 +38,10 @@ public class ImageService {
 
     @Transactional(readOnly = true)
     public Image findById(Long id) {
-        return Optional.ofNullable(id)
-                .map(imageRepository::findById)
-                        .orElseThrow(() -> new ResourceNotFoundException(
-                                "존재하지 않는 이미지입니다.(id: " + id + ")"))
-                .orElse(null);
+        if (id == null) return null;
+        return imageRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "존재하지 않는 이미지입니다.(id: " + id + ")"));
     }
 
     public static String getUrlFromImage(Image image) {

--- a/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
@@ -111,4 +111,7 @@ public class Restaurant extends BaseEntity {
         return  welcomeCount >= 2;
     }
 
+    public void setThumbnail(Image thumbnail){
+        this.thumbnail =  thumbnail;
+    }
 }

--- a/src/test/java/container/restaurant/server/domain/feed/FeedServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/feed/FeedServiceTest.java
@@ -85,6 +85,7 @@ class FeedServiceTest extends BaseServiceTest {
         when(userService.findById(user.getId())).thenReturn(user);
         when(restaurantService.findByDto(any())).thenReturn(restaurant);
         when(imageService.findById(any())).thenReturn(thumbnail);
+        when(feedRepository.findFirstByRestaurantIdAndThumbnailIdIsNotNullOrderByLikeCountDesc(any())).thenReturn(feed);
 
         FeedMenuDto mainMenuDto = FeedMenuDto.builder()
                 .menuName("mainMenu")


### PR DESCRIPTION
피드 쓰기 수행 시 식당의 대표 이미지도 함께 적용

기준 : 해당 식당으로 피드 조회 시 좋아요가 많고 이미지 가 있는 피드를 반환해 해당 이미지를 식당 대표이미지로 적용

처음 식당이 등록되는 경우 방금 등록된 피드의 이미지를 대표 이미지로 적용

피드 작성 시 식당 대표이미지 변경
피드 좋아요 시는 현재 적용 X