### PR TITLE
:sparkles: 식당 대표 메뉴 반환 추가

### DIFF
--- a/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedRepository.java
@@ -46,4 +46,6 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @EntityGraph(attributePaths = { "owner", "thumbnail", "restaurant" })
     Page<Feed> findAllByCreatedDateBetweenOrderByCreatedDateDesc(LocalDateTime from, LocalDateTime to, Pageable pageable);
 
+    @EntityGraph(attributePaths = { "thumbnail", "restaurant"})
+    Feed findFirstByRestaurantIdAndThumbnailIdIsNotNullOrderByLikeCountDesc(Long restaurantId);
 }

--- a/src/main/java/container/restaurant/server/domain/feed/FeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedService.java
@@ -141,9 +141,8 @@ public class FeedService {
         User user = userService.findById(ownerId);
         Restaurant restaurant = restaurantService.findByDto(dto.getRestaurantCreateDto());
         Image thumbnail = imageService.findById(dto.getThumbnailImageId());
-
         Feed feed = feedRepository.save(dto.toFeedWith(user, restaurant, thumbnail));
-
+        restaurant.setThumbnail(findRestaurantRepFeedThumbnail(restaurant));
         statisticsService.addRecentUser(user);
 
         feed.getOwner().feedCountUp();
@@ -213,5 +212,11 @@ public class FeedService {
                 .isLike(feedLikeRepository.existsByUserIdAndFeedId(loginId, feed.getId()))
                 .isScraped(scrapFeedRepository.existsByUserIdAndFeedId(loginId, feed.getId()))
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public Image findRestaurantRepFeedThumbnail(Restaurant restaurant) {
+        Feed repFeed = feedRepository.findFirstByRestaurantIdAndThumbnailIdIsNotNullOrderByLikeCountDesc(restaurant.getId());
+        return repFeed.getThumbnail();
     }
 }

--- a/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
@@ -111,4 +111,7 @@ public class Restaurant extends BaseEntity {
         return  welcomeCount >= 2;
     }
 
+    public void setThumbnail(Image thumbnail){
+        this.thumbnail =  thumbnail;
+    }
 }

--- a/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/Restaurant.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import container.restaurant.server.domain.base.BaseEntity;
 import container.restaurant.server.domain.feed.Feed;
 import container.restaurant.server.domain.feed.picture.Image;
-import container.restaurant.server.domain.restaurant.menu.Menu;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,10 +13,8 @@ import org.locationtech.jts.geom.Point;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.validation.constraints.NotNull;
-import java.util.List;
 
 import static container.restaurant.server.utils.SpatialUtils.createPointType;
 
@@ -40,9 +37,6 @@ public class Restaurant extends BaseEntity {
 
     @NotNull
     private double longitude;
-
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "restaurant")
-    private List<Menu> menu;
 
     @OneToOne(fetch = FetchType.LAZY)
     private Image thumbnail;

--- a/src/main/java/container/restaurant/server/domain/restaurant/RestaurantService.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/RestaurantService.java
@@ -1,6 +1,7 @@
 package container.restaurant.server.domain.restaurant;
 
 import container.restaurant.server.domain.restaurant.favorite.RestaurantFavoriteRepository;
+import container.restaurant.server.domain.restaurant.menu.MenuService;
 import container.restaurant.server.exception.ResourceNotFoundException;
 import container.restaurant.server.web.dto.restaurant.RestaurantInfoDto;
 import container.restaurant.server.web.dto.restaurant.RestaurantDetailDto;
@@ -18,6 +19,7 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final RestaurantFavoriteRepository restaurantFavoriteRepository;
+    private final MenuService menuService;
 
     @Transactional(readOnly = true)
     public RestaurantDetailDto getRestaurantInfoById(Long restaurantId, Long loginId) {
@@ -31,10 +33,10 @@ public class RestaurantService {
         return restaurantRepository.findNearByRestaurants(lat, lon, radius)
                 .stream()
                 .map(restaurant -> RestaurantNearInfoDto.from(restaurant,
-                        restaurantFavoriteRepository.existsByUserIdAndRestaurantId(loginId, restaurant.getId())))
+                        restaurantFavoriteRepository.existsByUserIdAndRestaurantId(loginId, restaurant.getId()),
+                        menuService.findTop2ByRestaurantAndIsMainTrueMenuNameList(restaurant)))
                 .collect(Collectors.toList());
     }
-
     // 식당 이름 검색 비활성화
 
     @Transactional

--- a/src/main/java/container/restaurant/server/domain/restaurant/menu/MenuRepository.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/menu/MenuRepository.java
@@ -3,10 +3,12 @@ package container.restaurant.server.domain.restaurant.menu;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     Optional<Menu> findByRestaurantAndName(Restaurant restaurant, String name);
 
+    List<Menu> findTop2ByRestaurantAndIsMainTrueAndNameNotOrderByCountDesc(Restaurant restaurant, String space);
 }

--- a/src/main/java/container/restaurant/server/domain/restaurant/menu/MenuService.java
+++ b/src/main/java/container/restaurant/server/domain/restaurant/menu/MenuService.java
@@ -1,8 +1,12 @@
 package container.restaurant.server.domain.restaurant.menu;
 
+import container.restaurant.server.domain.restaurant.Restaurant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -24,5 +28,12 @@ public class MenuService {
                     if (m.countDown() == 0)
                         menuRepository.delete(m);
                 });
+    }
+
+    @Transactional(readOnly = true )
+    public Set<String> findTop2ByRestaurantAndIsMainTrueMenuNameList(Restaurant restaurant){
+        return menuRepository.findTop2ByRestaurantAndIsMainTrueAndNameNotOrderByCountDesc(restaurant,"")
+                .stream().map(Menu::getName)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/container/restaurant/server/web/dto/restaurant/RestaurantNearInfoDto.java
+++ b/src/main/java/container/restaurant/server/web/dto/restaurant/RestaurantNearInfoDto.java
@@ -4,6 +4,7 @@ import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import lombok.Getter;
 import org.springframework.hateoas.RepresentationModel;
+import java.util.Set;
 
 @Getter
 public class RestaurantNearInfoDto extends RepresentationModel<RestaurantNearInfoDto> {
@@ -18,12 +19,13 @@ public class RestaurantNearInfoDto extends RepresentationModel<RestaurantNearInf
     private final Float difficultyAvg;
     private final Boolean isContainerFriendly;
     private final Boolean isFavorite;
+    private final Set<String> menuList;
 
-    public static RestaurantNearInfoDto from(Restaurant restaurant, Boolean isFavorite) {
-        return new RestaurantNearInfoDto(restaurant, isFavorite);
+    public static RestaurantNearInfoDto from(Restaurant restaurant, Boolean isFavorite, Set<String> menuList) {
+        return new RestaurantNearInfoDto(restaurant, isFavorite,menuList);
     }
 
-    protected RestaurantNearInfoDto(Restaurant restaurant, Boolean isFavorite) {
+    protected RestaurantNearInfoDto(Restaurant restaurant, Boolean isFavorite,Set<String> menuList) {
         this.id = restaurant.getId();
         this.name = restaurant.getName();
         this.address = restaurant.getAddress();
@@ -34,6 +36,7 @@ public class RestaurantNearInfoDto extends RepresentationModel<RestaurantNearInf
         this.image_path = ImageService.getUrlFromImage(restaurant.getThumbnail());
         this.isContainerFriendly = restaurant.isContainerFriendly();
         this.isFavorite = isFavorite;
+        this.menuList = menuList;
 
     }
 

--- a/src/main/java/container/restaurant/server/web/dto/restaurant/favorite/RestaurantFavoriteDto.java
+++ b/src/main/java/container/restaurant/server/web/dto/restaurant/favorite/RestaurantFavoriteDto.java
@@ -22,7 +22,7 @@ public class RestaurantFavoriteDto extends RepresentationModel<RestaurantFavorit
         this.id = restaurantFavorite.getId();
         this.createDate = restaurantFavorite.getCreatedDate()
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        this.restaurant = RestaurantNearInfoDto.from(restaurantFavorite.getRestaurant(), true);
+        this.restaurant = RestaurantNearInfoDto.from(restaurantFavorite.getRestaurant(), true, null);
         // 즐겨찾기한 정보를 불러오는 것이기에 무조건 isFavorite 은 true
     }
 


### PR DESCRIPTION
근처 식당 정보 조회 시 해당 식당의 메인 메뉴 2가지를 반환 

메인 메뉴가 1개이거나 중복인 경우 1개만 반환
없을경운 빈 배열이 반환
메뉴 이름이 공백인 경우 제외

메뉴 선정은 해당 식당에 저장된 메뉴의 count 값이 높은 순 2개 로 반환
count => 해당 메뉴를 사용하는 피드의 개수