### PR TITLE
🔒 토큰 기반 로그인(인증) 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:7.3.0'
 	implementation 'com.squareup.okhttp3:okhttp:4.9.1'
 
+	//=== JJWT 의존성 ===//
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
+			'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -113,13 +113,6 @@ include::{snippets}/banner/response-fields-beneath-_embedded.bannerInfoDtoList.a
 [[login]]
 == 로그인
 
-[[login-web]]
-=== 웹에서의 로그인
-`GET /login`
-
-OAuth 2.0 제공자에 아래 리다이렉트 URI 를 등록하여 로그인 및 회원가입을 할 수 있습니다.
-(웹에서 로그인/회원 가입시 사용하는 API 로, 모바일 앱에서는 다른 방식을 이용합니다.)
-
 [[login-token]]
 === 액세스 토큰으로 로그인
 
@@ -130,20 +123,12 @@ operation::login-token[snippets='curl-request,request-fields,http-response']
 
 응답 형식은 <<user-get>> 을 참조합니다. 로그인에 실패한 경우 _401 Unauthorized_ 상태를 응답합니다.
 
-로그인에 실패한 경우 <<user-create>>를 참조합니다.
-
 [[logout]]
 == 로그아웃
 `GET /logout`
 
 [[user]]
 == 사용자
-
-[[user-create]]
-=== 토큰으로 사용자 정보생성
-`POST /api/user`
-
-operation::user-create[snippets='curl-request,request-fields,http-response,response-headers']
 
 [[user-get]]
 === 사용자 정보 조회

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -110,25 +110,16 @@ operation::banners[snippets='curl-request,http-response']
 
 include::{snippets}/banner/response-fields-beneath-_embedded.bannerInfoDtoList.adoc[]
 
-[[login]]
-== 로그인
-
-[[login-token]]
-=== 액세스 토큰으로 로그인
-
-OAuth 2.0 제공자와 응답받은 액세스 토큰 만으로도 로그인이 가능합니다.
-서버에서는 해당 정보를 이용해 OAuth 2.0 에게 인증받은 유효한 토큰인지 확인 후 로그인 됩니다.
-
-operation::login-token[snippets='curl-request,request-fields,http-response']
-
-응답 형식은 <<user-get>> 을 참조합니다. 로그인에 실패한 경우 _401 Unauthorized_ 상태를 응답합니다.
-
-[[logout]]
-== 로그아웃
-`GET /logout`
-
 [[user]]
 == 사용자
+
+[[user-new-token]]
+=== 로그인 토큰 생성
+`POST /api/user`
+
+operation::user-new-token[snippets='curl-request,http-response,response-fields']
+
+사용자를 인증하기 위해서는 요청 헤더에 `Authorization` 속성을 `Bearer [생성된_인증_토큰]` 으로 설정해야합니다.
 
 [[user-get]]
 === 사용자 정보 조회

--- a/src/main/java/container/restaurant/server/config/AppConfig.java
+++ b/src/main/java/container/restaurant/server/config/AppConfig.java
@@ -1,5 +1,6 @@
 package container.restaurant.server.config;
 
+import container.restaurant.server.config.auth.JwtTokenFilter;
 import container.restaurant.server.process.oauth.OAuthAgentFactory;
 import container.restaurant.server.utils.jwt.JwtLoginService;
 import container.restaurant.server.utils.jwt.jjwt.JjwtLoginService;
@@ -30,4 +31,8 @@ public class AppConfig {
         return new JjwtLoginService();
     }
 
+    @Bean
+    public JwtTokenFilter jwtTokenFilter(JwtLoginService jwtLoginService) {
+        return new JwtTokenFilter(jwtLoginService);
+    }
 }

--- a/src/main/java/container/restaurant/server/config/AppConfig.java
+++ b/src/main/java/container/restaurant/server/config/AppConfig.java
@@ -1,6 +1,8 @@
 package container.restaurant.server.config;
 
 import container.restaurant.server.process.oauth.OAuthAgentFactory;
+import container.restaurant.server.utils.jwt.JwtLoginService;
+import container.restaurant.server.utils.jwt.jjwt.JjwtLoginService;
 import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
 import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +23,11 @@ public class AppConfig {
     @Bean
     public HttpTraceRepository getHttpTraceRepository() {
         return new InMemoryHttpTraceRepository();
+    }
+
+    @Bean
+    public JwtLoginService jwtParser() {
+        return new JjwtLoginService();
     }
 
 }

--- a/src/main/java/container/restaurant/server/config/AppConfig.java
+++ b/src/main/java/container/restaurant/server/config/AppConfig.java
@@ -2,6 +2,7 @@ package container.restaurant.server.config;
 
 import container.restaurant.server.config.auth.JwtTokenFilter;
 import container.restaurant.server.process.oauth.OAuthAgentFactory;
+import container.restaurant.server.process.oauth.OAuthAgentService;
 import container.restaurant.server.utils.jwt.JwtLoginService;
 import container.restaurant.server.utils.jwt.jjwt.JjwtLoginService;
 import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
@@ -34,5 +35,10 @@ public class AppConfig {
     @Bean
     public JwtTokenFilter jwtTokenFilter(JwtLoginService jwtLoginService) {
         return new JwtTokenFilter(jwtLoginService);
+    }
+
+    @Bean
+    public OAuthAgentService oAuthAgentService() {
+        return new OAuthAgentService(null);
     }
 }

--- a/src/main/java/container/restaurant/server/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/container/restaurant/server/config/auth/CustomOAuth2UserService.java
@@ -1,20 +1,16 @@
 package container.restaurant.server.config.auth;
 
-import container.restaurant.server.config.auth.dto.OAuthAttributes;
-import container.restaurant.server.domain.user.User;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
 import container.restaurant.server.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpSession;
-import java.util.Collections;
 
 @RequiredArgsConstructor
 @Service
@@ -32,17 +28,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
                 .getUserInfoEndpoint().getUserNameAttributeName();
 
-        OAuthAttributes attributes = OAuthAttributes.of(
+        CustomOAuth2User authUser = CustomOAuth2User.newUser(
                 registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
-        User user = userService.createOrUpdate(attributes.getIdentifier(), attributes::toEntity);
+        Long userId = userService.getUserIdFromIdentifier(authUser.getIdentifier());
 
-        httpSession.setAttribute("userId", user.getId());
+        httpSession.setAttribute("userId", userId);
 
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("USER")),
-                attributes.getAttributes(),
-                attributes.getNameAttributeKey());
+        return authUser;
     }
 
     private OAuth2User getUserFromRequest(OAuth2UserRequest userRequest) {

--- a/src/main/java/container/restaurant/server/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/container/restaurant/server/config/auth/CustomOAuth2UserService.java
@@ -35,8 +35,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(
                 registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
-        User user = userService.createOrUpdate(
-                attributes.getProvider(), attributes.getAuthId(), attributes::toEntity);
+        User user = userService.createOrUpdate(attributes.getIdentifier(), attributes::toEntity);
 
         httpSession.setAttribute("userId", user.getId());
 

--- a/src/main/java/container/restaurant/server/config/auth/JwtTokenFilter.java
+++ b/src/main/java/container/restaurant/server/config/auth/JwtTokenFilter.java
@@ -1,0 +1,41 @@
+package container.restaurant.server.config.auth;
+
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.utils.jwt.JwtLoginService;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtLoginService jwtLoginService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, @NotNull HttpServletResponse response,
+            @NotNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String header = request.getHeader(AUTHORIZATION);
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String token = header.split(" ")[1].trim();
+        CustomOAuth2User loginUser = jwtLoginService.parse(token);
+
+        SecurityContextHolder.getContext().setAuthentication(loginUser.getAuthentication());
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/container/restaurant/server/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/container/restaurant/server/config/auth/LoginUserArgumentResolver.java
@@ -1,8 +1,11 @@
 package container.restaurant.server.config.auth;
 
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -11,11 +14,14 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import javax.servlet.http.HttpSession;
 
+import static java.util.Optional.ofNullable;
+
 @RequiredArgsConstructor
 @Component
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final HttpSession httpSession;
+    private final UserService userService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -29,7 +35,14 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             @NotNull MethodParameter parameter, ModelAndViewContainer mavContainer,
             @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory
     ) {
-        return httpSession.getAttribute("userId");
+        return ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .filter(auth -> auth.getPrincipal() instanceof CustomOAuth2User)
+                .map(auth -> userService.getUserIdFromIdentifier(
+                        ((CustomOAuth2User) auth.getPrincipal()).getIdentifier()))
+                .orElseGet(() -> ofNullable(httpSession.getAttribute("userId"))
+                        .map(o -> Long.valueOf(o.toString()))
+                        .orElse(null)
+                );
     }
 
 }

--- a/src/main/java/container/restaurant/server/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/container/restaurant/server/config/auth/dto/OAuthAttributes.java
@@ -1,6 +1,7 @@
 package container.restaurant.server.config.auth.dto;
 
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +16,9 @@ public class OAuthAttributes {
 
     private final Map<String, Object> attributes;
 
-    private final String authId;
     private final String nickname;
     private final String email;
-    private final AuthProvider provider;
+    private final OAuth2Identifier identifier;
 
     private final String nameAttributeKey;
 
@@ -32,8 +32,7 @@ public class OAuthAttributes {
 
     public static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
-                .provider(AuthProvider.GOOGLE)
-                .authId(attributes.get("sub").toString())
+                .identifier(OAuth2Identifier.of(attributes.get("sub").toString(), OAuth2Registration.GOOGLE))
                 .email((String) attributes.get("email"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
@@ -51,8 +50,7 @@ public class OAuthAttributes {
         Map<String, String> kakaoAccount = (Map<String, String>) attributes.getOrDefault("kakao_account", Map.of());
 
         return OAuthAttributes.builder()
-                .provider(AuthProvider.KAKAO)
-                .authId(attributes.get("id").toString())
+                .identifier(OAuth2Identifier.of(attributes.get("id").toString(), OAuth2Registration.KAKAO))
                 .email(kakaoAccount.get("email"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
@@ -62,8 +60,7 @@ public class OAuthAttributes {
 
     public User toEntity() {
         return User.builder()
-                .authProvider(provider)
-                .authId(authId)
+                .identifier(identifier)
                 .email(email)
                 .build();
     }

--- a/src/main/java/container/restaurant/server/config/auth/user/CustomOAuth2User.java
+++ b/src/main/java/container/restaurant/server/config/auth/user/CustomOAuth2User.java
@@ -9,13 +9,14 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 @Getter
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, Serializable {
 
     //=== attributes 속성(일부는 JWT(RFC 7519) 스펙) ===//
 
@@ -38,7 +39,7 @@ public class CustomOAuth2User implements OAuth2User {
                 throw new IllegalArgumentException("인증 정보 생성에 실패했습니다.(해당 속성이 없습니다:" + s + ")" );
         }
 
-        this.attributes = attributes;
+        this.attributes = Map.copyOf(attributes);
         this.authorities = Set.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
@@ -63,7 +64,7 @@ public class CustomOAuth2User implements OAuth2User {
 
    @Override
     public String getName() {
-        return (String) getAttributes().get(SUBJECT);
+        return getAttributes().get(SUBJECT).toString();
     }
 
     public Authentication getAuthentication() {

--- a/src/main/java/container/restaurant/server/config/auth/user/CustomOAuth2User.java
+++ b/src/main/java/container/restaurant/server/config/auth/user/CustomOAuth2User.java
@@ -1,0 +1,92 @@
+package container.restaurant.server.config.auth.user;
+
+import container.restaurant.server.domain.user.OAuth2Identifier;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    //=== attributes 속성(일부는 JWT(RFC 7519) 스펙) ===//
+
+    public static final String SUBJECT = "sub";
+    public static final String EXPIRATION_TIME = "exp";
+    public static final String ISSUED_AT = "iat";
+    public static final String EMAIL = "email";
+    public static final String REGISTRATION = "registration";
+
+    public static final List<String> REQUIRED_ATTRIBUTES = List.of(SUBJECT, REGISTRATION, EXPIRATION_TIME);
+
+    //=== 필수 속성 ===//
+
+    private final Map<String, Object> attributes;
+    private final Set<GrantedAuthority> authorities;
+
+    protected CustomOAuth2User(Map<String, Object> attributes) {
+        for (String s : REQUIRED_ATTRIBUTES) {
+            if (!attributes.containsKey(s))
+                throw new IllegalArgumentException("인증 정보 생성에 실패했습니다.(해당 속성이 없습니다:" + s + ")" );
+        }
+
+        this.attributes = attributes;
+        this.authorities = Set.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    //=== 정적 팩토리 메서드 ===//
+
+    public static CustomOAuth2User newUser(
+            String registrationId, String userNameAttributeName, Map<String, Object> attributes
+    ) {
+        try {
+            return from(OAuth2Registration.valueOf(registrationId.toUpperCase())
+                    .extractAuthInfo(userNameAttributeName, attributes));
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException("지원하지 않는 로그인 제공자입니다.(" + registrationId + ")");
+        }
+    }
+
+    public static CustomOAuth2User from(Map<String, Object> attributes) {
+        return new CustomOAuth2User(attributes);
+    }
+
+    //=== public 메서드 ===//
+
+   @Override
+    public String getName() {
+        return (String) getAttributes().get(SUBJECT);
+    }
+
+    public Authentication getAuthentication() {
+        return new OAuth2AuthenticationToken(this, getAuthorities(),
+                getAttributes().get(REGISTRATION).toString());
+    }
+
+    public OAuth2Identifier getIdentifier() {
+        return OAuth2Identifier.of(
+                getAttributes().get(SUBJECT).toString(),
+                getAttributes().get(REGISTRATION).toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomOAuth2User that = (CustomOAuth2User) o;
+        return Objects.equals(getAttributes(), that.getAttributes()) && Objects.equals(getAuthorities(), that.getAuthorities());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAttributes(), getAuthorities());
+    }
+}

--- a/src/main/java/container/restaurant/server/domain/user/OAuth2Identifier.java
+++ b/src/main/java/container/restaurant/server/domain/user/OAuth2Identifier.java
@@ -1,0 +1,36 @@
+package container.restaurant.server.domain.user;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import java.util.Locale;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Embeddable
+public class OAuth2Identifier {
+
+    @Column(nullable = false, name = "auth_id")
+    private String subject;
+
+    @Column(nullable = false, name = "auth_provider")
+    @Enumerated(EnumType.STRING)
+    private OAuth2Registration registration;
+
+    public static OAuth2Identifier of(String subject, OAuth2Registration registration) {
+        return new OAuth2Identifier(subject, registration);
+    }
+
+    public static OAuth2Identifier of(String subject, String registrationId) {
+        return new OAuth2Identifier(subject, OAuth2Registration.valueOf(registrationId.toUpperCase(Locale.ROOT)));
+    }
+
+}

--- a/src/main/java/container/restaurant/server/domain/user/OAuth2Registration.java
+++ b/src/main/java/container/restaurant/server/domain/user/OAuth2Registration.java
@@ -1,7 +1,45 @@
 package container.restaurant.server.domain.user;
 
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static container.restaurant.server.config.auth.user.CustomOAuth2User.*;
+
+@RequiredArgsConstructor
 public enum OAuth2Registration {
 
-    KAKAO, APPLE, GOOGLE
+    KAKAO((userNameAttributeName, attributes) -> {
+        //noinspection unchecked
+        Map<String, String> kakaoAccount = (Map<String, String>)
+                attributes.getOrDefault("kakao_account", Map.of());
+
+        LocalDateTime now = LocalDateTime.now();
+
+        return Map.of(
+                SUBJECT, attributes.get(userNameAttributeName),
+                EXPIRATION_TIME, getLongTime(now.plusMonths(1)),
+                ISSUED_AT, getLongTime(now),
+                REGISTRATION, "KAKAO",
+                EMAIL, kakaoAccount.get("email")
+        );
+    }),
+    APPLE((String userNameAttributeName, Map<String, Object> attributes) -> {
+        throw new UnsupportedOperationException("아직 지원하지 않는 로그인 제공자입니다.(APPLE)");}),
+    GOOGLE((String userNameAttributeName, Map<String, Object> attributes) -> {
+        throw new UnsupportedOperationException("아직 지원하지 않는 로그인 제공자입니다.(GOOGLE)");});
+
+    private final BiFunction<String, Map<String, Object>, Map<String, Object>> extractionFunction;
+
+    public Map<String, Object> extractAuthInfo(String userNameAttributeName, Map<String, Object> attributes) {
+        return extractionFunction.apply(userNameAttributeName, attributes);
+    }
+
+    private static Long getLongTime(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
 
 }

--- a/src/main/java/container/restaurant/server/domain/user/OAuth2Registration.java
+++ b/src/main/java/container/restaurant/server/domain/user/OAuth2Registration.java
@@ -1,6 +1,6 @@
 package container.restaurant.server.domain.user;
 
-public enum AuthProvider {
+public enum OAuth2Registration {
 
     KAKAO, APPLE, GOOGLE
 

--- a/src/main/java/container/restaurant/server/domain/user/User.java
+++ b/src/main/java/container/restaurant/server/domain/user/User.java
@@ -17,12 +17,8 @@ import static container.restaurant.server.domain.user.ContainerLevel.*;
 @Entity(name = "TB_USERS")
 public class User extends BaseCreatedTimeEntity {
 
-    @Column(nullable = false)
-    private String authId;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private AuthProvider authProvider;
+    @Embedded
+    private OAuth2Identifier identifier;
 
     private String email;
 
@@ -50,10 +46,9 @@ public class User extends BaseCreatedTimeEntity {
     private PushToken pushToken;
 
     @Builder
-    protected User(String authId, AuthProvider authProvider, String email,
+    protected User(OAuth2Identifier identifier, String email,
                    Image profile, String nickname, PushToken pushToken) {
-        this.authId = authId;
-        this.authProvider = authProvider;
+        this.identifier = identifier;
         this.email = email;
         this.nickname = nickname;
         this.profile = profile;
@@ -68,6 +63,14 @@ public class User extends BaseCreatedTimeEntity {
 
     public String getLevelTitle() {
         return this.containerLevel.getTitle();
+    }
+
+    public OAuth2Registration getRegistration() {
+        return this.identifier.getRegistration();
+    }
+
+    public String getSubject() {
+        return this.identifier.getSubject();
     }
 
     public void setNickname(String nickname) {

--- a/src/main/java/container/restaurant/server/domain/user/UserRepository.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserRepository.java
@@ -11,7 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByAuthProviderAndAuthId(AuthProvider provider, String authId);
+    Optional<User> findByIdentifier(OAuth2Identifier identifier);
 
     boolean existsUserByNickname(String nickName);
 

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -42,12 +42,19 @@ public class UserService {
     @Transactional
     public UserDto.Token newToken(UserDto.ToRequestToken dto) {
         CustomOAuth2User authUser = oAuthAgentService.getAuthUser(dto);
-         Long userId = userRepository.findByIdentifier(authUser.getIdentifier())
+        Long userId = userRepository.findByIdentifier(authUser.getIdentifier())
                  .orElseGet(() -> userRepository.save(
                          User.builder().identifier(authUser.getIdentifier()).build()))
                  .getId();
-         String newToken = jwtLoginService.tokenize(authUser);
+        String newToken = jwtLoginService.tokenize(authUser);
         return new UserDto.Token(userId, newToken);
+    }
+
+    @Transactional
+    public Long getUserIdFromIdentifier(OAuth2Identifier identifier) {
+        return userRepository.findByIdentifier(identifier)
+                .map(User::getId)
+                .orElse(null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -2,7 +2,8 @@ package container.restaurant.server.domain.user;
 
 import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.exception.ResourceNotFoundException;
-import container.restaurant.server.process.oauth.OAuthAgentFactory;
+import container.restaurant.server.process.oauth.OAuthAgentService;
+import container.restaurant.server.utils.jwt.JwtLoginService;
 import container.restaurant.server.web.dto.user.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,9 @@ public class UserService {
 
     private final ImageService imageService;
 
-    private final OAuthAgentFactory authAgentFactory;
+    private final OAuthAgentService oAuthAgentService;
+
+    private final JwtLoginService jwtLoginService;
 
     @Transactional
     public User createOrUpdate(
@@ -35,14 +38,15 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    @Transactional
+    public UserDto.Token newToken(UserDto.ToRequestToken dto) {
+        return null;
+    }
+
     @Transactional(readOnly = true)
     public UserDto.Info getUserInfoById(Long id) throws ResourceNotFoundException {
 
         return UserDto.Info.from(findById(id));
-    }
-
-    public void newToken(UserDto.Create dto) {
-
     }
 
     @Transactional

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package container.restaurant.server.domain.user;
 
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
 import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.exception.ResourceNotFoundException;
 import container.restaurant.server.process.oauth.OAuthAgentService;
@@ -40,7 +41,13 @@ public class UserService {
 
     @Transactional
     public UserDto.Token newToken(UserDto.ToRequestToken dto) {
-        return null;
+        CustomOAuth2User authUser = oAuthAgentService.getAuthUser(dto);
+         Long userId = userRepository.findByIdentifier(authUser.getIdentifier())
+                 .orElseGet(() -> userRepository.save(
+                         User.builder().identifier(authUser.getIdentifier()).build()))
+                 .getId();
+         String newToken = jwtLoginService.tokenize(authUser);
+        return new UserDto.Token(userId, newToken);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -31,9 +31,9 @@ public class UserService {
 
     @Transactional
     public User createOrUpdate(
-            AuthProvider provider, String authId, Supplier<@Valid ? extends User> supplier
+            OAuth2Identifier identifier, Supplier<@Valid ? extends User> supplier
     ) {
-        User user = userRepository.findByAuthProviderAndAuthId(provider, authId)
+        User user = userRepository.findByIdentifier(identifier)
                 .orElseGet(supplier);
 
         return userRepository.save(user);
@@ -46,7 +46,7 @@ public class UserService {
                 .orElseThrow(() -> new ValidationException("유효하지 않은 액세스토큰입니다."));
 
         User newUser = of(attrs.toEntity())
-                .flatMap(user -> userRepository.findByAuthProviderAndAuthId(user.getAuthProvider(), user.getAuthId()))
+                .flatMap(user -> userRepository.findByIdentifier(user.getIdentifier()))
                 .orElseGet(() -> userRepository.save(attrs.toEntity()));
 
         ofNullable(dto.getProfileId())
@@ -59,8 +59,7 @@ public class UserService {
     public Optional<UserDto.Info> tokenLogin(UserDto.TokenLogin dto) {
         return authAgentFactory.get(dto.getProvider())
                 .getAuthAttrFrom(dto.getAccessToken())
-                .flatMap(attributes -> userRepository
-                        .findByAuthProviderAndAuthId(attributes.getProvider(), attributes.getAuthId())
+                .flatMap(attributes -> userRepository.findByIdentifier(attributes.getIdentifier())
                         .map(UserDto.Info::from));
     }
 

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -1,6 +1,5 @@
 package container.restaurant.server.domain.user;
 
-import container.restaurant.server.config.auth.dto.OAuthAttributes;
 import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.exception.ResourceNotFoundException;
 import container.restaurant.server.process.oauth.OAuthAgentFactory;
@@ -10,13 +9,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
-import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 @RequiredArgsConstructor
@@ -39,34 +35,14 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    @Transactional
-    public UserDto.Info createFrom(UserDto.Create dto) {
-        OAuthAttributes attrs = authAgentFactory.get(dto.getProvider())
-                .getAuthAttrFrom(dto.getAccessToken())
-                .orElseThrow(() -> new ValidationException("유효하지 않은 액세스토큰입니다."));
-
-        User newUser = of(attrs.toEntity())
-                .flatMap(user -> userRepository.findByIdentifier(user.getIdentifier()))
-                .orElseGet(() -> userRepository.save(attrs.toEntity()));
-
-        ofNullable(dto.getProfileId())
-                .ifPresent(profileId -> newUser.setProfile(imageService.findById(profileId)));
-
-        return UserDto.Info.from(newUser);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<UserDto.Info> tokenLogin(UserDto.TokenLogin dto) {
-        return authAgentFactory.get(dto.getProvider())
-                .getAuthAttrFrom(dto.getAccessToken())
-                .flatMap(attributes -> userRepository.findByIdentifier(attributes.getIdentifier())
-                        .map(UserDto.Info::from));
-    }
-
     @Transactional(readOnly = true)
     public UserDto.Info getUserInfoById(Long id) throws ResourceNotFoundException {
 
         return UserDto.Info.from(findById(id));
+    }
+
+    public void newToken(UserDto.Create dto) {
+
     }
 
     @Transactional

--- a/src/main/java/container/restaurant/server/exception/UnauthorizedException.java
+++ b/src/main/java/container/restaurant/server/exception/UnauthorizedException.java
@@ -1,6 +1,11 @@
 package container.restaurant.server.exception;
 
 public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public UnauthorizedException(String message) {
         super(message);
     }

--- a/src/main/java/container/restaurant/server/process/oauth/KakaoOAuthAgent.java
+++ b/src/main/java/container/restaurant/server/process/oauth/KakaoOAuthAgent.java
@@ -1,6 +1,7 @@
 package container.restaurant.server.process.oauth;
 
 import container.restaurant.server.config.auth.dto.OAuthAttributes;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -34,5 +35,19 @@ public class KakaoOAuthAgent implements OAuthAgent {
                     .bodyToMono(Map.class)
                     .block())
                 .map(OAuthAttributes::ofKakao);
+    }
+
+    @Override
+    public CustomOAuth2User getAuthUserFrom(String accessToken) {
+        //noinspection unchecked
+        return CustomOAuth2User.newUser(
+                "kakao", "id",
+                webClient
+                        .get()
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                        .header(HttpHeaders.AUTHORIZATION, String.join("", "Bearer ", accessToken))
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .block());
     }
 }

--- a/src/main/java/container/restaurant/server/process/oauth/OAuthAgent.java
+++ b/src/main/java/container/restaurant/server/process/oauth/OAuthAgent.java
@@ -1,6 +1,7 @@
 package container.restaurant.server.process.oauth;
 
 import container.restaurant.server.config.auth.dto.OAuthAttributes;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
 
 import java.util.Optional;
 
@@ -17,5 +18,7 @@ public interface OAuthAgent {
      * @return 사용자 정보가 담긴 {@link OAuthAttributes}에 대한 {@link Optional}
      */
     Optional<OAuthAttributes> getAuthAttrFrom(String accessToken);
+
+    CustomOAuth2User getAuthUserFrom(String accessToken);
 
 }

--- a/src/main/java/container/restaurant/server/process/oauth/OAuthAgentFactory.java
+++ b/src/main/java/container/restaurant/server/process/oauth/OAuthAgentFactory.java
@@ -1,29 +1,29 @@
 package container.restaurant.server.process.oauth;
 
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
 
 import java.util.Locale;
 import java.util.Map;
 
 public class OAuthAgentFactory {
 
-    private final Map<AuthProvider, OAuthAgent> agentMap;
+    private final Map<OAuth2Registration, OAuthAgent> agentMap;
 
     public static OAuthAgentFactory createDefaultFactory() {
         return new OAuthAgentFactory(Map.of(
-                AuthProvider.KAKAO, new KakaoOAuthAgent()
+                OAuth2Registration.KAKAO, new KakaoOAuthAgent()
         ));
     }
 
-    private OAuthAgentFactory(Map<AuthProvider, OAuthAgent> map) {
+    private OAuthAgentFactory(Map<OAuth2Registration, OAuthAgent> map) {
         this.agentMap = map;
     }
 
-    public OAuthAgent get(AuthProvider provider) {
+    public OAuthAgent get(OAuth2Registration provider) {
         return agentMap.get(provider);
     }
 
     public OAuthAgent get(String provider) {
-        return agentMap.get(AuthProvider.valueOf(provider.toUpperCase(Locale.ROOT)));
+        return agentMap.get(OAuth2Registration.valueOf(provider.toUpperCase(Locale.ROOT)));
     }
 }

--- a/src/main/java/container/restaurant/server/process/oauth/OAuthAgentService.java
+++ b/src/main/java/container/restaurant/server/process/oauth/OAuthAgentService.java
@@ -1,0 +1,27 @@
+package container.restaurant.server.process.oauth;
+
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.exception.UnauthorizedException;
+import container.restaurant.server.web.dto.user.UserDto;
+
+public class OAuthAgentService {
+
+    private final static OAuthAgentFactory DEFAULT_OAUTH_AGENT_FACTORY =
+            OAuthAgentFactory.createDefaultFactory();
+
+    private final OAuthAgentFactory agentFactory;
+
+    public OAuthAgentService(OAuthAgentFactory agentFactory) {
+        this.agentFactory = agentFactory != null ? agentFactory : DEFAULT_OAUTH_AGENT_FACTORY;
+    }
+
+    public CustomOAuth2User getAuthUser(UserDto.ToRequestToken dto) {
+        try {
+            return agentFactory.get(dto.getProvider())
+                    .getAuthUserFrom(dto.getAccessToken());
+        } catch (RuntimeException ex) {
+            throw new UnauthorizedException("액세스 토큰 인증에 실패했습니다.", ex);
+        }
+    }
+
+}

--- a/src/main/java/container/restaurant/server/utils/jwt/JwtLoginService.java
+++ b/src/main/java/container/restaurant/server/utils/jwt/JwtLoginService.java
@@ -1,0 +1,14 @@
+package container.restaurant.server.utils.jwt;
+
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface JwtLoginService {
+
+    String tokenize(OAuth2User user);
+
+    CustomOAuth2User parse(String token);
+
+}

--- a/src/main/java/container/restaurant/server/utils/jwt/jjwt/JjwtLoginService.java
+++ b/src/main/java/container/restaurant/server/utils/jwt/jjwt/JjwtLoginService.java
@@ -1,0 +1,33 @@
+package container.restaurant.server.utils.jwt.jjwt;
+
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.exception.UnauthorizedException;
+import container.restaurant.server.utils.jwt.JwtLoginService;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.security.Key;
+
+public class JjwtLoginService implements JwtLoginService {
+
+    public final static Key KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    @Override
+    public String tokenize(OAuth2User user) {
+        return Jwts.builder().setClaims(user.getAttributes()).signWith(KEY).compact();
+    }
+
+    @Override
+    public CustomOAuth2User parse(String token) {
+        try {
+            Jws<Claims> claimsJws = Jwts.parserBuilder().setSigningKey(KEY).build().parseClaimsJws(token);
+            return CustomOAuth2User.from(claimsJws.getBody());
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException("만료된 토큰입니다.");
+        } catch (JwtException e) {
+            throw new UnauthorizedException("잘못된 토큰입니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/container/restaurant/server/web/UserController.java
+++ b/src/main/java/container/restaurant/server/web/UserController.java
@@ -1,11 +1,9 @@
 package container.restaurant.server.web;
 
 import container.restaurant.server.config.auth.LoginId;
-import container.restaurant.server.constant.Header;
 import container.restaurant.server.domain.user.UserService;
 import container.restaurant.server.domain.user.validator.NicknameConstraint;
 import container.restaurant.server.exception.FailedAuthorizationException;
-import container.restaurant.server.exception.UnauthorizedException;
 import container.restaurant.server.web.dto.user.UserDto;
 import container.restaurant.server.web.linker.FeedLinker;
 import container.restaurant.server.web.linker.RestaurantFavoriteLinker;
@@ -16,7 +14,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
 import java.util.List;
 
 import static java.util.Optional.ofNullable;
@@ -32,39 +29,6 @@ public class UserController {
     private final UserLinker userLinker;
     private final FeedLinker feedLinker;
     private final RestaurantFavoriteLinker restaurantFavoriteLinker;
-
-    @PostMapping
-    public ResponseEntity<?> createWithToken(
-            @LoginId Long loginId, @RequestBody @Valid UserDto.Create dto
-    ) {
-        if (loginId != null)
-            return ResponseEntity.noContent().build();
-
-        UserDto.Info newUser = userService.createFrom(dto);
-        setLoginUser(newUser.getId());
-
-        return ResponseEntity
-                .created(userLinker.getUserById(newUser.getId()).toUri())
-                .header(Header.USER_ID, newUser.getId().toString())
-                .build();
-    }
-
-    @PostMapping("login")
-    public ResponseEntity<?> tokenLogin(
-            @LoginId Long loginId, @RequestBody UserDto.TokenLogin dto
-    ) {
-        if (loginId != null)
-            return ResponseEntity.noContent().build();
-
-        return userService.tokenLogin(dto)
-                .map(info -> {
-                    setLoginUser(info.getId());
-                    return ResponseEntity.ok()
-                            .header(Header.USER_ID, info.getId().toString())
-                            .body(setLinks(info, info.getId()));
-                })
-                .orElseThrow(() -> new UnauthorizedException("로그인 실패 - 해당 사용자를 찾을 수 없습니다."));
-    }
 
     @GetMapping
     public ResponseEntity<?> getCurrentUser(@LoginId Long loginId) {

--- a/src/main/java/container/restaurant/server/web/UserController.java
+++ b/src/main/java/container/restaurant/server/web/UserController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpSession;
 import java.util.List;
 
 import static java.util.Optional.ofNullable;
@@ -66,7 +65,6 @@ public class UserController {
             throw new FailedAuthorizationException("해당 사용자의 정보를 수정할 수 없습니다.(id:" + id + ")");
 
         userService.deleteById(id);
-        logout();
 
         return ResponseEntity.noContent().build();
     }
@@ -98,21 +96,4 @@ public class UserController {
                         restaurantFavoriteLinker.findAllByUser().withRel("restaurant-favorite")
                 ));
     }
-
-    // FIXME 임시 로그인 방편
-    private final HttpSession httpSession;
-    @GetMapping("temp-login")
-    public ResponseEntity<?> tempLogin() {
-        setLoginUser(1L);
-        return ResponseEntity.noContent().build();
-    }
-
-    private void setLoginUser(Long loginId) {
-        httpSession.setAttribute("userId", loginId);
-    }
-
-    private void logout() {
-        setLoginUser(null);
-    }
-
 }

--- a/src/main/java/container/restaurant/server/web/UserController.java
+++ b/src/main/java/container/restaurant/server/web/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<UserDto.Token> tokenRequest(@RequestBody UserDto.ToRequestToken dto) {
-        return null;
+        return ResponseEntity.ok(userService.newToken(dto));
     }
 
     @GetMapping

--- a/src/main/java/container/restaurant/server/web/UserController.java
+++ b/src/main/java/container/restaurant/server/web/UserController.java
@@ -29,6 +29,11 @@ public class UserController {
     private final FeedLinker feedLinker;
     private final RestaurantFavoriteLinker restaurantFavoriteLinker;
 
+    @PostMapping
+    public ResponseEntity<UserDto.Token> tokenRequest(@RequestBody UserDto.ToRequestToken dto) {
+        return null;
+    }
+
     @GetMapping
     public ResponseEntity<?> getCurrentUser(@LoginId Long loginId) {
         return ResponseEntity.of(ofNullable(loginId)

--- a/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
+++ b/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
@@ -5,10 +5,7 @@ import container.restaurant.server.domain.push.PushToken;
 import container.restaurant.server.domain.user.OAuth2Registration;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.validator.NicknameConstraint;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.hateoas.RepresentationModel;
 
 import javax.validation.constraints.NotEmpty;
@@ -16,10 +13,9 @@ import javax.validation.constraints.NotNull;
 
 public interface UserDto {
 
+    @RequiredArgsConstructor
     @Getter
-    @Builder
-    @AllArgsConstructor
-    class Create {
+    class ToRequestToken {
 
         @NotNull
         private final OAuth2Registration provider;
@@ -27,28 +23,31 @@ public interface UserDto {
         @NotEmpty
         private final String accessToken;
 
-        private final Long profileId;
+    }
 
-        private final PushToken pushToken;
-
+    @RequiredArgsConstructor
+    @Getter
+    class Token {
+        private final Long id;
+        private final String token;
     }
 
     @Getter
     class Info extends RepresentationModel<Info> {
-        private final Long id;
 
+        private final Long id;
         private final String email;
         private final String nickname;
         private final String profile;
         private final String levelTitle;
         private final Integer feedCount;
         private final Integer scrapCount;
+
         private final Integer bookmarkedCount;
 
         public static UserDto.Info from(User user) {
             return new UserDto.Info(user);
         }
-
         protected Info(User user) {
             this.id = user.getId();
             this.email = user.getEmail();
@@ -59,13 +58,14 @@ public interface UserDto {
             this.scrapCount = user.getScrapCount();
             this.bookmarkedCount = user.getBookmarkedCount();
         }
-    }
 
+    }
     @Getter
     @NoArgsConstructor
     @Builder
     @AllArgsConstructor
     class Update {
+
 
         @NicknameConstraint
         private String nickname;
@@ -75,30 +75,29 @@ public interface UserDto {
         private PushToken pushToken;
 
     }
-
     @Getter
     class NicknameExists extends RepresentationModel<NicknameExists> {
 
         private final String nickname;
+
         private final Boolean exists;
 
         protected NicknameExists(String nickname, Boolean exists) {
             this.nickname = nickname;
             this.exists = exists;
         }
-
         public static NicknameExists of(String nickname, Boolean exists) {
             return new NicknameExists(nickname, exists);
         }
-    }
 
+    }
     @Getter
     @AllArgsConstructor
     class TokenLogin {
 
         private final String accessToken;
+
         private final OAuth2Registration provider;
 
     }
-
 }

--- a/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
+++ b/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
@@ -2,7 +2,7 @@ package container.restaurant.server.web.dto.user;
 
 import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.domain.push.PushToken;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.validator.NicknameConstraint;
 import lombok.AllArgsConstructor;
@@ -22,7 +22,7 @@ public interface UserDto {
     class Create {
 
         @NotNull
-        private final AuthProvider provider;
+        private final OAuth2Registration provider;
 
         @NotEmpty
         private final String accessToken;
@@ -97,7 +97,7 @@ public interface UserDto {
     class TokenLogin {
 
         private final String accessToken;
-        private final AuthProvider provider;
+        private final OAuth2Registration provider;
 
     }
 

--- a/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
+++ b/src/main/java/container/restaurant/server/web/dto/user/UserDto.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 public interface UserDto {
 
     @RequiredArgsConstructor
+    @EqualsAndHashCode
     @Getter
     class ToRequestToken {
 

--- a/src/test/java/container/restaurant/server/BaseMockTest.java
+++ b/src/test/java/container/restaurant/server/BaseMockTest.java
@@ -1,0 +1,13 @@
+package container.restaurant.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.MockitoAnnotations;
+
+public abstract class BaseMockTest {
+
+    @BeforeEach
+    void setMock() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+}

--- a/src/test/java/container/restaurant/server/config/auth/JwtTokenFilterTest.java
+++ b/src/test/java/container/restaurant/server/config/auth/JwtTokenFilterTest.java
@@ -1,0 +1,83 @@
+package container.restaurant.server.config.auth;
+
+import container.restaurant.server.BaseMockTest;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.utils.jwt.JwtLoginService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@DisplayName("JWT 토큰 필터 단위 테스트")
+class JwtTokenFilterTest extends BaseMockTest {
+
+    @InjectMocks JwtTokenFilter jwtTokenFilter;
+
+    @Mock JwtLoginService jwtLoginService;
+
+    @Mock HttpServletRequest request;
+    @Mock HttpServletResponse response;
+    @Mock FilterChain filterChain;
+
+    @Mock SecurityContext context;
+
+    @BeforeEach
+    void setSecurityContextHolder() {
+        SecurityContextHolder.setContext(context);
+    }
+
+    @ParameterizedTest(name = "Authorization: {0}")
+    @CsvSource({ ",", "no proper format"})
+    @DisplayName("Authorization 헤더가 유효하지 않은 경우")
+    void Authorization_헤더가_유효하지_않은_경우(String authorization) throws Exception {
+        //given 유효하지 않은 Authorization 헤더가 주어졌을 때
+        when(request.getHeader(AUTHORIZATION)).thenReturn(authorization);
+
+        //when 필터를 통과했을 때
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        //then Authentication 설정되지 않음 / 다음 필터 체인을 발생시킴
+        verify(context, never()).setAuthentication(any());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("정상 동작")
+    void 정상_동작() throws Exception {
+        //given 유효한 Authorization 헤더가 주어졌을 때
+        String token = "[TEST_TOKEN]";
+        when(request.getHeader(AUTHORIZATION)).thenReturn(makeBearer(token));
+
+        CustomOAuth2User mockedUser = mock(CustomOAuth2User.class);
+        when(jwtLoginService.parse(token)).thenReturn(mockedUser);
+
+        Authentication mockedAuthentication = mock(Authentication.class);
+        when(mockedUser.getAuthentication()).thenReturn(mockedAuthentication);
+
+        //when 필터를 통과했을 때
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        //then Authentication 가 설정됨 / 다음 필터 체인을 발생시킴
+        assert SecurityContextHolder.getContext() == context;
+        verify(context).setAuthentication(mockedAuthentication);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    private String makeBearer(String token) {
+        return String.join(" ", "Bearer", token);
+    }
+    
+}

--- a/src/test/java/container/restaurant/server/config/auth/user/CustomOAuth2UserTest.java
+++ b/src/test/java/container/restaurant/server/config/auth/user/CustomOAuth2UserTest.java
@@ -1,0 +1,96 @@
+package container.restaurant.server.config.auth.user;
+
+import container.restaurant.server.domain.user.OAuth2Identifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Map;
+import java.util.Set;
+
+import static container.restaurant.server.config.auth.user.CustomOAuth2User.*;
+import static container.restaurant.server.domain.user.OAuth2Registration.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CustomOAuth2User 단위 테스트")
+class CustomOAuth2UserTest {
+
+    @Test
+    @DisplayName("인증된 유저 테스트")
+    void 카카오로_인증된_유저_테스트() {
+        //given
+        String registrationId = "kakao";
+        String userNameAttributeName = "id";
+
+        String sub = "testId";
+        String email = "testEmail";
+        Map<String, Object> attrs = Map.of(
+                "id", sub,
+                "kakao_account", Map.of(
+                        "email", email));
+        
+        //when
+        CustomOAuth2User result = CustomOAuth2User.newUser(registrationId, userNameAttributeName, attrs);
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getAttributes())
+                .containsEntry(SUBJECT, sub)
+                .containsEntry(REGISTRATION, KAKAO)
+                .containsEntry(EMAIL, email)
+                .containsKey(EXPIRATION_TIME)
+                .containsKey(ISSUED_AT);
+        assertThat(result.getAuthorities().size()).isEqualTo(1);
+        assertThat(result.getAuthorities()).allMatch(a -> "ROLE_USER".equals(a.getAuthority()));
+        assertThat(result.getName()).isEqualTo(sub);
+        assertThat(result.getIdentifier()).isEqualTo(OAuth2Identifier.of(sub, registrationId));
+    }
+
+    @Test
+    @DisplayName("정적 팩토리 메서드 테스트")
+    void 정적_팩토리_메서드_테스트() {
+        //given
+        String sub = "testSUBJECT";
+        String registrationId = "kakao";
+        Map<String, Object> map = Map.of(
+                SUBJECT, sub,
+                EXPIRATION_TIME, "testEXPIRATION_TIME",
+                ISSUED_AT, "testISSUED_AT",
+                EMAIL, "testEMAIL",
+                REGISTRATION, registrationId
+        );
+
+        //when
+        CustomOAuth2User result = from(map);
+
+        //then
+        assertThat(result.getAttributes()).isEqualTo(map);
+        assertThat(result.getAuthorities()).allMatch(a -> "ROLE_USER".equals(a.getAuthority()));
+        assertThat(result.getName()).isEqualTo(sub);
+        assertThat(result.getIdentifier()).isEqualTo(OAuth2Identifier.of(sub, registrationId));
+    }
+
+    @Test
+    @DisplayName("Authentication 생성 테스트")
+    void Authentication_생성_테스트() {
+        //given
+        CustomOAuth2User user = mock(CustomOAuth2User.class);
+        doReturn(Set.of(new SimpleGrantedAuthority("ROLE_USER"))).when(user).getAuthorities();
+        when(user.getAuthentication()).thenCallRealMethod();
+        when(user.getAttributes()).thenReturn(Map.of(REGISTRATION, KAKAO));
+        when(user.getName()).thenReturn("name");
+
+        //when
+        Authentication authentication = user.getAuthentication();
+
+        //then
+        assertThat(authentication.getAuthorities()).allMatch(a -> "ROLE_USER".equals(a.getAuthority()));
+        assertThat(authentication.getName()).isEqualTo("name");
+        assertThat(authentication.getPrincipal()).isEqualTo(user);
+        assertThat(authentication.getCredentials()).isEqualTo("");
+        assertThat(authentication.getDetails()).isEqualTo(null);
+    }
+    
+}

--- a/src/test/java/container/restaurant/server/config/auth/user/CustomOAuth2UserTest.java
+++ b/src/test/java/container/restaurant/server/config/auth/user/CustomOAuth2UserTest.java
@@ -38,7 +38,7 @@ class CustomOAuth2UserTest {
         assertThat(result).isNotNull();
         assertThat(result.getAttributes())
                 .containsEntry(SUBJECT, sub)
-                .containsEntry(REGISTRATION, KAKAO)
+                .containsEntry(REGISTRATION, KAKAO.toString())
                 .containsEntry(EMAIL, email)
                 .containsKey(EXPIRATION_TIME)
                 .containsKey(ISSUED_AT);

--- a/src/test/java/container/restaurant/server/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/comment/CommentRepositoryTest.java
@@ -7,7 +7,8 @@ import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import container.restaurant.server.domain.restaurant.RestaurantRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -53,8 +54,7 @@ class CommentRepositoryTest {
                 .build());
 
         user = userRepository.save(User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test@test.com")
                 .nickname("testNickname")
                 .profile(image)

--- a/src/test/java/container/restaurant/server/domain/comment/CommentServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/comment/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package container.restaurant.server.domain.comment;
 
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.exception.ResourceNotFoundException;
 import container.restaurant.server.domain.feed.Category;
 import container.restaurant.server.domain.feed.Feed;
@@ -67,8 +68,7 @@ class CommentServiceTest {
         users = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             users.add(User.builder()
-                    .authId("authId" + i)
-                    .authProvider(AuthProvider.KAKAO)
+                    .identifier(OAuth2Identifier.of("authId" + i, OAuth2Registration.KAKAO))
                     .email("me" + i + "@test.com")
                     .profile(image)
                     .nickname("TestNickname" + i)

--- a/src/test/java/container/restaurant/server/domain/comment/like/CommentLikeRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/comment/like/CommentLikeRepositoryTest.java
@@ -4,7 +4,8 @@ import container.restaurant.server.domain.comment.Comment;
 import container.restaurant.server.domain.feed.Category;
 import container.restaurant.server.domain.feed.Feed;
 import container.restaurant.server.domain.restaurant.Restaurant;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +29,8 @@ class CommentLikeRepositoryTest {
     @Test
     void test() {
         //given
-        User user = em.persist(User.builder().authId("AUTH_ID").authProvider(AuthProvider.KAKAO)
+        User user = em.persist(User.builder()
+                .identifier(OAuth2Identifier.of("AUTH_ID", OAuth2Registration.KAKAO))
                 .nickname("TEST NICKNAME").email("test@test.com").build());
 
         Restaurant restaurant = em.persist(Restaurant.builder().lon(0.0).lat(0.0)

--- a/src/test/java/container/restaurant/server/domain/comment/like/CommentLikeServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/comment/like/CommentLikeServiceTest.java
@@ -10,7 +10,8 @@ import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import container.restaurant.server.domain.restaurant.RestaurantRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -65,8 +66,7 @@ class CommentLikeServiceTest {
                 .build());
 
         user = userRepository.save(User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test@test.com")
                 .profile(image)
                 .nickname("testNickname")

--- a/src/test/java/container/restaurant/server/domain/feed/FeedRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/feed/FeedRepositoryTest.java
@@ -5,7 +5,8 @@ import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import container.restaurant.server.domain.restaurant.RestaurantRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import container.restaurant.server.domain.user.scrap.ScrapFeed;
@@ -70,8 +71,7 @@ public class FeedRepositoryTest {
         users = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             users.add(User.builder()
-                    .authId("authId" + i)
-                    .authProvider(AuthProvider.KAKAO)
+                    .identifier(OAuth2Identifier.of("authId" + i, OAuth2Registration.KAKAO))
                     .email("me" + i + "@test.com")
                     .profile(image)
                     .nickname("TestNickname" + i)

--- a/src/test/java/container/restaurant/server/domain/feed/like/FeedLikeRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/feed/like/FeedLikeRepositoryTest.java
@@ -7,7 +7,8 @@ import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import container.restaurant.server.domain.restaurant.RestaurantRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -54,8 +55,7 @@ class FeedLikeRepositoryTest {
                 .build());
 
         User user = userRepository.save(User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test@test.com")
                 .nickname("testNickname")
                 .profile(image)

--- a/src/test/java/container/restaurant/server/domain/user/UserRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/user/UserRepositoryTest.java
@@ -27,16 +27,15 @@ class UserRepositoryTest {
         //given
         String email = "test@test";
         String authId = "authId";
-        AuthProvider provider = AuthProvider.KAKAO;
+        OAuth2Registration provider = OAuth2Registration.KAKAO;
         User newUser = userRepository.save(User.builder()
-                .authId(authId)
-                .authProvider(provider)
+                .identifier(OAuth2Identifier.of(authId, provider))
                 .nickname("testNickname")
                 .email(email)
                 .build());
 
         //when
-        User found = userRepository.findByAuthProviderAndAuthId(provider, authId)
+        User found = userRepository.findByIdentifier(newUser.getIdentifier())
                 .orElse(null);
 
         //then
@@ -62,8 +61,7 @@ class UserRepositoryTest {
     void testDuplicatedNickname() {
         //given
         User user1 = User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test1@test")
                 .build();
         final User user2 = User.builder()
@@ -88,8 +86,7 @@ class UserRepositoryTest {
         //given
         String nickname = "추가된닉네임";
         User user1 = User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test@test")
                 .nickname(nickname)
                 .build();

--- a/src/test/java/container/restaurant/server/domain/user/UserServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/user/UserServiceTest.java
@@ -1,0 +1,98 @@
+package container.restaurant.server.domain.user;
+
+import container.restaurant.server.BaseMockTest;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.process.oauth.OAuthAgentService;
+import container.restaurant.server.utils.jwt.JwtLoginService;
+import container.restaurant.server.web.dto.user.UserDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static container.restaurant.server.domain.user.OAuth2Registration.KAKAO;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("UserService 단위 테스트")
+public class UserServiceTest extends BaseMockTest {
+
+    @InjectMocks UserService userService;
+
+    @Mock UserRepository userRepository;
+    @Mock OAuthAgentService oAuthAgentService;
+    @Mock JwtLoginService jwtLoginService;
+
+    @Test
+    @DisplayName("토큰 요청 DTO 로 토큰 생성 - 새 유저 생성")
+    void 토큰_요청_DTO_로_토큰_생성__새_유저_생성() {
+        //given KAKAO 인증을 사용하는 토큰 요청 DTO, 유저 Principal, 인증 식별 VO, 생성될 유저 ID, 생성될 토큰이 주어졌을 때
+        UserDto.ToRequestToken dto = new UserDto.ToRequestToken(KAKAO, "[KAKAO_ACCESS_TOKEN]");
+        CustomOAuth2User auth2User = mock(CustomOAuth2User.class);
+        OAuth2Identifier identifier = new OAuth2Identifier("[KAKAO_ID]", KAKAO);
+        long newUserId = 1L;
+        String newToken = "[CREATED_JWT]";
+
+        when(oAuthAgentService.getAuthUser(dto)).thenReturn(auth2User);
+        when(auth2User.getIdentifier()).thenReturn(identifier);
+        when(userRepository.findByIdentifier(identifier)).thenReturn(empty());
+        when(userRepository.save(any())).thenAnswer(invocation -> {
+            User user = spy((User) invocation.getArgument(0));
+            when(user.getId()).thenReturn(newUserId);
+            return user;
+        });
+        when(jwtLoginService.tokenize(auth2User)).thenReturn(newToken);
+
+        //when 인증토큰을 요청하면
+        UserDto.Token result = userService.newToken(dto);
+
+        //then Null 이 아닌 DTO 가 반환됨 / 생성된 유저 ID 가 포함됨 / 생성된 토큰이 포함됨
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(newUserId);
+        assertThat(result.getToken()).isEqualTo(newToken);
+    }
+
+    @Test
+    @DisplayName("토큰 요청 DTO 로 토큰 생성 - 존재하는 유저")
+    void 토큰_요청_DTO_로_토큰_생성__존재하는_유저() {
+        //given KAKAO 인증을 사용하는 토큰 요청 DTO, 유저 Principal, 인증 식별 VO, 저장된 유저, 생성될 토큰이 주어졌을 때
+        UserDto.ToRequestToken dto = new UserDto.ToRequestToken(KAKAO, "[KAKAO_ACCESS_TOKEN]");
+        CustomOAuth2User auth2User = mock(CustomOAuth2User.class);
+        OAuth2Identifier identifier = new OAuth2Identifier("[KAKAO_ID]", KAKAO);
+        String newToken = "[CREATED_JWT]";
+        User user = mock(User.class);
+
+        when(oAuthAgentService.getAuthUser(dto)).thenReturn(auth2User);
+        when(auth2User.getIdentifier()).thenReturn(identifier);
+        when(userRepository.findByIdentifier(identifier)).thenReturn(of(user));
+        when(user.getId()).thenReturn(1L);
+        when(jwtLoginService.tokenize(auth2User)).thenReturn(newToken);
+
+        //when 인증토큰을 요청하면
+        UserDto.Token result = userService.newToken(dto);
+
+        //then Null 이 아닌 DTO 가 반환됨 / 생성된 유저 ID 가 포함됨 / 생성된 토큰이 포함됨
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(user.getId());
+        assertThat(result.getToken()).isEqualTo(newToken);
+    }
+
+    @Test
+    @DisplayName("토큰 요청 DTO 로 토큰 생성 - 잘못된 액세스 토큰")
+    void 토큰_요청_DTO_로_토큰_생성__잘못된_액세스_토큰() {
+        //given KAKAO 인증을 사용하는 토큰 요청 DTO, 유저 Principal, 인증 식별 VO, 생성될 유저 ID, 생성될 토큰이 주어졌을 때
+        UserDto.ToRequestToken dto = new UserDto.ToRequestToken(KAKAO, "[KAKAO_ACCESS_TOKEN]");
+        RuntimeException ex = mock(RuntimeException.class);
+
+        when(oAuthAgentService.getAuthUser(dto)).thenThrow(ex);
+
+        //expect 새 인증토큰을 요청하면 발생한 예외가 전이됨
+        assertThatThrownBy(() -> userService.newToken(dto))
+                .isEqualTo(ex);
+    }
+
+}

--- a/src/test/java/container/restaurant/server/domain/user/UserServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/user/UserServiceTest.java
@@ -95,4 +95,36 @@ public class UserServiceTest extends BaseMockTest {
                 .isEqualTo(ex);
     }
 
+    @Test
+    @DisplayName("OAuth 식별자로 ID 얻어오기")
+    void OAuth_식별자로_ID_얻어오기() {
+        //given OAuth 식별자와 조회 결과 유저 가 주어졌을 때
+        OAuth2Identifier identifier = mock(OAuth2Identifier.class);
+        User user = mock(User.class);
+
+        when(user.getId()).thenReturn(1L);
+        when(userRepository.findByIdentifier(identifier)).thenReturn(of(user));
+
+        //when 주어진 OAuth 식별자로 ID 조회하면
+        Long result = userService.getUserIdFromIdentifier(identifier);
+
+        //then 주어진 유저의 ID 가 반환됨
+        assertThat(result).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("OAuth 식별자로 ID 얻어오기 - 유저가 없는 경우")
+    void OAuth_식별자로_ID_얻어오기__유저가_없는_경우() {
+        //given 일치하는 유저가 없는 OAuth 식별자가 주어졌을 때
+        OAuth2Identifier identifier = mock(OAuth2Identifier.class);
+
+        when(userRepository.findByIdentifier(identifier)).thenReturn(empty());
+
+        //when 주어진 OAuth 식별자로 ID 조회하면
+        Long result = userService.getUserIdFromIdentifier(identifier);
+
+        //then null 이 반환됨
+        assertThat(result).isNull();
+    }
+
 }

--- a/src/test/java/container/restaurant/server/domain/user/UserTest.java
+++ b/src/test/java/container/restaurant/server/domain/user/UserTest.java
@@ -23,7 +23,7 @@ class UserTest {
     void testBuilder() {
         //given
         String authId = "testId";
-        AuthProvider provider = AuthProvider.KAKAO;
+        OAuth2Registration provider = OAuth2Registration.KAKAO;
         String email = "test@test.com";
         String nickname = "testNickname";
         Image profile = new Image("profilePath");
@@ -31,8 +31,7 @@ class UserTest {
 
         //when
         User user = User.builder()
-                .authId(authId)
-                .authProvider(provider)
+                .identifier(OAuth2Identifier.of(authId, provider))
                 .email(email)
                 .nickname(nickname)
                 .profile(profile)
@@ -40,8 +39,7 @@ class UserTest {
                 .build();
 
         //then
-        assertThat(user.getAuthId()).isEqualTo(authId);
-        assertThat(user.getAuthProvider()).isEqualTo(provider);
+        assertThat(user.getIdentifier()).isEqualTo(OAuth2Identifier.of(authId, provider));
         assertThat(user.getEmail()).isEqualTo(email);
         assertThat(user.getNickname()).isEqualTo(nickname);
         assertThat(user.getProfile().getUrl()).isEqualTo(profile.getUrl());

--- a/src/test/java/container/restaurant/server/domain/user/scrap/ScrapFeedRepositoryTest.java
+++ b/src/test/java/container/restaurant/server/domain/user/scrap/ScrapFeedRepositoryTest.java
@@ -7,7 +7,8 @@ import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
 import container.restaurant.server.domain.restaurant.Restaurant;
 import container.restaurant.server.domain.restaurant.RestaurantRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -56,8 +57,7 @@ class ScrapFeedRepositoryTest {
                 .build());
 
         User user = userRepository.save(User.builder()
-                .authId("authId")
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of("authId", OAuth2Registration.KAKAO))
                 .email("test@test.com")
                 .nickname("testNickname")
                 .profile(image)

--- a/src/test/java/container/restaurant/server/process/oauth/OAuthAgentServiceTest.java
+++ b/src/test/java/container/restaurant/server/process/oauth/OAuthAgentServiceTest.java
@@ -1,0 +1,54 @@
+package container.restaurant.server.process.oauth;
+
+import container.restaurant.server.BaseMockTest;
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.web.dto.user.UserDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static container.restaurant.server.domain.user.OAuth2Registration.KAKAO;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("OAuthAgentService 단위 테스트")
+class OAuthAgentServiceTest extends BaseMockTest {
+
+    @InjectMocks OAuthAgentService oAuthAgentService;
+
+    @Mock OAuthAgentFactory agentFactory;
+    @Mock OAuthAgent agent;
+
+    @BeforeEach
+    void 팩토리_스텁() {
+        when(agentFactory.get(anyString())).thenReturn(agent);
+        when(agentFactory.get(any(OAuth2Registration.class))).thenReturn(agent);
+    }
+
+    @Test
+    @DisplayName("토큰 요청 DTO 로 유저 Principal 생성 테스트")
+    void 토큰_요청_DTO_로_유저_Principal_생성_테스트() {
+        //given 토큰 생성 DTO 가 주어지고 agent 의 동작이 스텁되어 있을 때
+        UserDto.ToRequestToken dto = new UserDto.ToRequestToken(KAKAO, "[KAKAO_ACCESS_TOKEN]");
+
+        CustomOAuth2User auth2User = mock(CustomOAuth2User.class);
+        when(agent.getAuthUserFrom(dto.getAccessToken())).thenReturn(auth2User);
+
+        //when 주어진 토큰 생성 DTO 로 Principal 을 생성하면
+        CustomOAuth2User result = oAuthAgentService.getAuthUser(dto);
+
+        //then 해당 Principal 은 agent 에 스텁된 Principal 과 동일함
+        assertThat(result).isEqualTo(auth2User);
+    }
+
+}

--- a/src/test/java/container/restaurant/server/utils/jwt/jjwt/JjwtLoginServiceTest.java
+++ b/src/test/java/container/restaurant/server/utils/jwt/jjwt/JjwtLoginServiceTest.java
@@ -1,0 +1,69 @@
+package container.restaurant.server.utils.jwt.jjwt;
+
+import container.restaurant.server.config.auth.user.CustomOAuth2User;
+import container.restaurant.server.exception.UnauthorizedException;
+import io.jsonwebtoken.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("JjwtLoginService 단위 테스트")
+class JjwtLoginServiceTest {
+
+    JjwtLoginService service = new JjwtLoginService();
+
+    @Test
+    @DisplayName("인증 받은 유저의 토큰 처리 테스트")
+    void 인증_받은_유저의_토큰_처리_테스트() {
+        //given 인증 받은 유저가 주어졌을 때
+        Map<String, Object> attrs = Map.of(
+                "id", "testId",
+                "kakao_account", Map.of(
+                        "email", "testEmail"));
+
+        CustomOAuth2User givenUser = CustomOAuth2User.newUser(
+                "kakao", "id", attrs);
+
+        //when 주어진 유저를 토큰화하고, 해당 토큰을 파싱하면
+        String token = service.tokenize(givenUser);
+        OAuth2User result = service.parse(token);
+
+        //then 주어진 유저가 반환됨
+        assertThat(result).isEqualTo(givenUser);
+    }
+
+    @Test
+    @DisplayName("만료 기한이 지난 토큰 테스트")
+    void 만료_기한이_지난_토큰_테스트() {
+        //given 만료 기한이 지난 토큰이 주어졌을 때
+        String token = Jwts.builder()
+                .setExpiration(new Date(new Date().getTime() - 1000))
+                .signWith(JjwtLoginService.KEY)
+                .compact();
+
+        //expect 주어진 토큰을 파싱하면 UnauthorizedException 예외가 발생
+        assertThatThrownBy(() -> service.parse(token))
+                .isExactlyInstanceOf(UnauthorizedException.class)
+                .hasMessage("만료된 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰 테스트")
+    void 잘못된_토큰_테스트() {
+        //given 잘못된 토큰이 주어졌을 때
+        String token = "INVALID";
+
+        //expect 주어진 토큰을 파싱하면 UnauthorizedException 예외가 발생
+        assertThatThrownBy(() -> service.parse(token))
+                .isExactlyInstanceOf(UnauthorizedException.class)
+                .hasMessage("잘못된 토큰입니다.");
+
+    }
+
+}

--- a/src/test/java/container/restaurant/server/web/CommentControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/CommentControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 class CommentControllerTest extends BaseFeedAndCommentControllerTest {
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 쓰기 테스트")
     void createComment() throws Exception{
         //given
@@ -69,6 +71,7 @@ class CommentControllerTest extends BaseFeedAndCommentControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 업데이트")
     void updateCommentById() throws Exception {
         //given
@@ -84,6 +87,7 @@ class CommentControllerTest extends BaseFeedAndCommentControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 삭제")
     void deleteCommentById() throws Exception {
 

--- a/src/test/java/container/restaurant/server/web/CommentLikeControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/CommentLikeControllerTest.java
@@ -7,19 +7,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.restdocs.hypermedia.HypermediaDocumentation;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,6 +24,7 @@ class CommentLikeControllerTest extends BaseFeedAndCommentControllerTest {
     CommentLikeRepository commentLikeRepository;
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 좋아요 테스트")
     void userLikeComment() throws Exception {
 
@@ -49,6 +43,7 @@ class CommentLikeControllerTest extends BaseFeedAndCommentControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 좋아요 취소 테스트")
     void userCancelLikeComment() throws Exception {
         commentLikeRepository.save(CommentLike.of(myself, myFeedComment));

--- a/src/test/java/container/restaurant/server/web/FeedControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/FeedControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -432,6 +433,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 쓰기")
     public void testCreateFeed() throws Exception {
         //given
@@ -482,6 +484,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 쓰기 실패")
     public void testCreateFeedFailed() throws Exception {
         //given
@@ -501,6 +504,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 수정")
     public void testUpdateFeed() throws Exception {
         //given
@@ -555,6 +559,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 수정 실패")
     public void testFailedUpdateFeed() throws Exception {
         //given
@@ -590,6 +595,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 삭제")
     public void testDeleteFeed() throws Exception {
         //given
@@ -607,6 +613,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 삭제 실패 - 존재않는 피드")
     public void testFailedDeleteFeedById() throws Exception {
         //given
@@ -620,6 +627,7 @@ class FeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 삭제 실패 - 다른 사용자의 피드")
     public void testFailedDeleteFeedBySession() throws Exception {
         //given

--- a/src/test/java/container/restaurant/server/web/FeedLikeControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/FeedLikeControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.List;
 
@@ -38,6 +39,7 @@ class FeedLikeControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 좋아요")
     void testUserLikeFeed() throws Exception {
         //given 초기 FeeLike 사이즈가 주어졌을 때
@@ -72,6 +74,7 @@ class FeedLikeControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("이미 좋아요한 피드 좋아요 - 아무일 엄슴")
     void testUserLikeFeedExists() throws Exception {
         //given otherFeed 를 좋아요한 myself 가 주어졌을 때
@@ -105,6 +108,7 @@ class FeedLikeControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 좋아요 취소")
     void testUserCancelLikeFeed() throws Exception {
         //given otherFeed 를 좋아요한 myself 가 주어졌을 때

--- a/src/test/java/container/restaurant/server/web/FeedLikeControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/FeedLikeControllerTest.java
@@ -104,17 +104,6 @@ class FeedLikeControllerTest extends BaseUserAndFeedControllerTest {
                 .isEqualTo(othersFeed.getLikeCount());
     }
 
-    // FIXME 임시 로그인 방편
-//    @Test
-//    @DisplayName("인증되지 않은 유저의 좋아요 실패")
-//    void failUnauthenticatedUser() throws Exception {
-//        //given other 유저가 작성한 피드가 주어졌을 때
-//
-//        //then 인증되지 않은 유저가 주어진 피드를 스크랩하면 login 리다이렉트
-//        mvc.perform(post("/api/like/feed/{feedId}", othersFeed.getId()))
-//                .andExpect(status().isFound());
-//    }
-
     @Test
     @DisplayName("피드 좋아요 취소")
     void testUserCancelLikeFeed() throws Exception {

--- a/src/test/java/container/restaurant/server/web/ImageControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/ImageControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
@@ -26,6 +27,7 @@ class ImageControllerTest extends BaseMvcControllerTest {
     @MockBean private ImageService imageService;
 
     @Test
+    @WithMockUser(roles = "USER")
     void testUploadImageFile() throws Exception {
         Image testImage = spy(new Image("IMAGE_URI"));
         when(testImage.getId()).thenReturn(3L);

--- a/src/test/java/container/restaurant/server/web/PushControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/PushControllerTest.java
@@ -5,6 +5,7 @@ import container.restaurant.server.web.base.BaseUserAndFeedControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -18,6 +19,7 @@ class PushControllerTest extends BaseUserAndFeedControllerTest {
     PushTokenService pushTokenService;
 
     @Test
+    @WithMockUser(roles = "USER")
     void registerClientPushToken() throws Exception {
         String testToken = "ASDFDWAQWERASDFZXCV1";
 
@@ -27,6 +29,7 @@ class PushControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     void deleteClientPushToken() throws Exception {
         String testToken = "ASDFDWAQWERASDFZXCV2";
         Long id = pushTokenService.registerPushToken(testToken).getId();

--- a/src/test/java/container/restaurant/server/web/ReportControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/ReportControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -38,6 +39,7 @@ class ReportControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 신고")
     void testReportFeed() throws Exception {
         for (int i = 0; i < 2; i++) {
@@ -58,6 +60,7 @@ class ReportControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("댓글 신고")
     void testReportComment() throws Exception {
         //given

--- a/src/test/java/container/restaurant/server/web/RestaurantControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/RestaurantControllerTest.java
@@ -3,6 +3,7 @@ package container.restaurant.server.web;
 import container.restaurant.server.web.base.BaseUserAndFeedControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
@@ -53,6 +54,7 @@ class RestaurantControllerTest extends BaseUserAndFeedControllerTest {
 //    }
 
     @Test
+    @WithMockUser(roles = "USER")
     void updateVanish() throws Exception {
 
         mvc.perform(post("/api/restaurant/vanish/{restaurantId}", restaurant.getId()))

--- a/src/test/java/container/restaurant/server/web/RestaurantFavoriteControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/RestaurantFavoriteControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
@@ -31,6 +32,7 @@ class RestaurantFavoriteControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     void userFavoriteRestaurant() throws Exception {
 
         mvc.perform(post("/api/favorite/restaurant/{restaurantId}",restaurant.getId())
@@ -45,6 +47,7 @@ class RestaurantFavoriteControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     void userCancelFavoriteRestaurant() throws Exception {
         restaurantFavoriteService.userFavoriteRestaurant(myself.getId(), restaurant.getId());
 

--- a/src/test/java/container/restaurant/server/web/ScrapFeedControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/ScrapFeedControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,6 +47,7 @@ class ScrapFeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("피드 스크랩하기")
     void scrapFeed() throws Exception {
         //given other 유저가 작성한 피드가 주어졌을 때
@@ -76,6 +78,7 @@ class ScrapFeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("중복되는 피드 스크랩하기")
     void failScrapFeed() throws Exception {
         //given 유저가 이미 스크랩한 피드와 when 동작 전 시간이 주어졌을 때
@@ -118,6 +121,7 @@ class ScrapFeedControllerTest extends BaseUserAndFeedControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("스크랩 취소")
     void cancelScrapFeed() throws Exception {
         //given 유저가 이미 스크랩한 피드가 주어졌을 때

--- a/src/test/java/container/restaurant/server/web/ScrapFeedControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/ScrapFeedControllerTest.java
@@ -117,17 +117,6 @@ class ScrapFeedControllerTest extends BaseUserAndFeedControllerTest {
         assertThat(scrap.getCreatedDate()).isBefore(now);
     }
 
-    // FIXME 임시 로그인 방편
-//    @Test
-//    @DisplayName("인증되지 않은 유저의 스크랩 실패")
-//    void failUnauthenticatedUser() throws Exception {
-//        //given other 유저가 작성한 피드가 주어졌을 때
-//
-//        //then 인증되지 않은 유저가 주어진 피드를 스크랩하면 login 리다이렉트
-//        mvc.perform(post("/api/scrap/{feedId}", othersFeed.getId()))
-//                .andExpect(status().isFound());
-//    }
-
     @Test
     @DisplayName("스크랩 취소")
     void cancelScrapFeed() throws Exception {

--- a/src/test/java/container/restaurant/server/web/UserControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.ConstraintViolationException;
@@ -120,6 +121,7 @@ class UserControllerTest extends BaseUserControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("사용자 닉네임, 프로필 업데이트")
     void testUpdateUser() throws Exception {
         String nickname = "this는nikname이라능a";
@@ -157,6 +159,7 @@ class UserControllerTest extends BaseUserControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("사용자 업데이트 실패 (400)")
     void testFailToUpdateUserBy400() throws Exception {
         String nickname = "this는nikname이라능!";
@@ -183,6 +186,7 @@ class UserControllerTest extends BaseUserControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("사용자 업데이트 실패 (403)")
     void testFailToUpdateUserBy403() throws Exception {
         String nickname = "this는nikname이라능a";
@@ -206,6 +210,7 @@ class UserControllerTest extends BaseUserControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("사용자 탈퇴")
     void testDeleteUser() throws Exception {
         mvc.perform(
@@ -218,6 +223,7 @@ class UserControllerTest extends BaseUserControllerTest {
     }
 
     @Test
+    @WithMockUser(roles = "USER")
     @DisplayName("사용자 탈퇴 실패 (403)")
     void testFailToDeleteUser() throws Exception {
         mvc.perform(

--- a/src/test/java/container/restaurant/server/web/UserControllerUnitTest.java
+++ b/src/test/java/container/restaurant/server/web/UserControllerUnitTest.java
@@ -1,0 +1,43 @@
+package container.restaurant.server.web;
+
+import container.restaurant.server.BaseMockTest;
+import container.restaurant.server.domain.user.UserService;
+import container.restaurant.server.web.dto.user.UserDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
+
+import static container.restaurant.server.domain.user.OAuth2Registration.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+
+@DisplayName("UserController 단위 테스트")
+class UserControllerUnitTest extends BaseMockTest {
+
+    @InjectMocks UserController userController;
+
+    @Mock UserService userService;
+
+    @Test
+    @DisplayName("인증 토큰 생성 테스트")
+    void 인증_토큰_생성_테스트() {
+        //given 스텁된 토큰 요청 DTO 와 토큰 DTO 가 주어졌을 때
+        UserDto.ToRequestToken dto = new UserDto.ToRequestToken(KAKAO, "[KAKAO_ACCESS_TOKEN]");
+        UserDto.Token token = mock(UserDto.Token.class);
+
+        when(userService.newToken(dto)).thenReturn(token);
+
+        //when 주어진 토큰 요청 DTO 로 토큰을 요청하면
+        ResponseEntity<UserDto.Token> result = userController.tokenRequest(dto);
+
+        //then status OK / 주어진 토큰 DTO 가 반환됨
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCode()).isEqualTo(OK);
+        assertThat(result.getBody()).isEqualTo(token);
+    }
+
+}

--- a/src/test/java/container/restaurant/server/web/base/BaseUserControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/base/BaseUserControllerTest.java
@@ -2,7 +2,8 @@ package container.restaurant.server.web.base;
 
 import container.restaurant.server.domain.feed.picture.Image;
 import container.restaurant.server.domain.feed.picture.ImageRepository;
-import container.restaurant.server.domain.user.AuthProvider;
+import container.restaurant.server.domain.user.OAuth2Registration;
+import container.restaurant.server.domain.user.OAuth2Identifier;
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -35,8 +36,7 @@ public abstract class BaseUserControllerTest extends BaseMvcControllerTest {
                 .build());
 
         myself = userRepository.save(User.builder()
-                .authId(myselfAuthId)
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of(myselfAuthId, OAuth2Registration.KAKAO))
                 .email("me@test.com")
                 .profile(image)
                 .nickname("나의닉네임")
@@ -44,8 +44,7 @@ public abstract class BaseUserControllerTest extends BaseMvcControllerTest {
 
         myselfSession.setAttribute("userId", myself.getId());
         other = userRepository.save(User.builder()
-                .authId(otherAuthId)
-                .authProvider(AuthProvider.KAKAO)
+                .identifier(OAuth2Identifier.of(otherAuthId, OAuth2Registration.KAKAO))
                 .email("you@test.com")
                 .profile(image)
                 .nickname("남의닉네임")


### PR DESCRIPTION
주요 변경 사항
- `POST /api/user` 요청으로 인증 토큰을 생성 가능
- 요청 헤더의 `Authorization` 속성으로 토큰 기반 인증을 사용 가능
- DOCS 변경 사항
  - 기존 액세스 토큰으로 로그인/회원가입 내용 삭제 (기능도 삭제)
  - 웹 로그인 내용 삭제 (기능은 유지됩니다.)

Closes #134 