### PR TITLE
통계(모두의 용기)의 유저정보 업데이트 되지 않는 문제 해결, 공유 변수 thread-safe 한 구조로 변경

### DIFF
--- a/src/main/java/container/restaurant/server/domain/statistics/LatestWriterList.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/LatestWriterList.java
@@ -1,0 +1,57 @@
+package container.restaurant.server.domain.statistics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class LatestWriterList<T> {
+
+    private List<T> latestWriters;
+    private final int recentUserMaxCount;
+    private static final int DEFAULT_RECENT_USER_MAX_COUNT = 100;
+
+    public LatestWriterList() {
+        this.latestWriters = toList(new ArrayList<>());
+        this.recentUserMaxCount = DEFAULT_RECENT_USER_MAX_COUNT;
+    }
+
+    public LatestWriterList(int recentUserMaxCount) {
+        this.latestWriters = toList(new ArrayList<>());
+        this.recentUserMaxCount = recentUserMaxCount;
+    }
+
+    private List<T> toList(List<T> list) {
+        return Collections.synchronizedList(list);
+    }
+
+    public List<T> getList() {
+        return Collections.unmodifiableList(latestWriters);
+    }
+
+    public boolean add(T item) {
+        if (!latestWriters.remove(item) && latestWriters.size() > recentUserMaxCount) {
+            latestWriters.remove(0);
+        }
+        return latestWriters.add(item);
+    }
+
+    public boolean update(T item) {
+        int index = latestWriters.indexOf(item);
+        if (index == -1) {
+            return false;
+        }
+
+        latestWriters.remove(index);
+        latestWriters.add(index, item);
+        return true;
+    }
+
+    public void remove(T item) {
+        latestWriters.remove(item);
+    }
+
+    public void replaceAll(List<T> list) {
+        latestWriters = toList(list);
+    }
+
+}

--- a/src/main/java/container/restaurant/server/domain/statistics/LatestWriterList.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/LatestWriterList.java
@@ -1,7 +1,9 @@
 package container.restaurant.server.domain.statistics;
 
+import static java.util.Collections.synchronizedList;
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 class LatestWriterList<T> {
@@ -11,21 +13,17 @@ class LatestWriterList<T> {
     private static final int DEFAULT_RECENT_USER_MAX_COUNT = 100;
 
     public LatestWriterList() {
-        this.latestWriters = toList(new ArrayList<>());
+        this.latestWriters = synchronizedList(new ArrayList<>());
         this.recentUserMaxCount = DEFAULT_RECENT_USER_MAX_COUNT;
     }
 
     public LatestWriterList(int recentUserMaxCount) {
-        this.latestWriters = toList(new ArrayList<>());
+        this.latestWriters = synchronizedList(new ArrayList<>());
         this.recentUserMaxCount = recentUserMaxCount;
     }
 
-    private List<T> toList(List<T> list) {
-        return Collections.synchronizedList(list);
-    }
-
     public List<T> getList() {
-        return Collections.unmodifiableList(latestWriters);
+        return unmodifiableList(latestWriters);
     }
 
     public boolean add(T item) {
@@ -51,7 +49,7 @@ class LatestWriterList<T> {
     }
 
     public void replaceAll(List<T> list) {
-        latestWriters = toList(list);
+        latestWriters = synchronizedList(list);
     }
 
 }

--- a/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
@@ -8,6 +8,9 @@ import container.restaurant.server.domain.user.UserRepository;
 import container.restaurant.server.domain.user.UserService;
 import container.restaurant.server.web.dto.statistics.StatisticsDto;
 import container.restaurant.server.web.dto.statistics.UserProfileDto;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +33,7 @@ import static org.springframework.data.domain.Pageable.unpaged;
 @Service
 @Log4j2
 public class StatisticsService implements ApplicationListener<ApplicationStartedEvent> {
-    private static final int MAX_COUNT = 100;
+    public static final int RECENT_USER_MAX_COUNT = 100;
     private final UserService userService;
     private final RestaurantService restaurantService;
     private final RecommendFeedService recommendFeedService;
@@ -38,13 +41,13 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
     private final FeedRepository feedRepository;
     private final UserRepository userRepository;
 
-    private int todayFeedCount = 0;
+    private final AtomicInteger todayFeedCount = new AtomicInteger(0);
 
-    private Deque<UserProfileDto> latestWriters = new LinkedList<>();
-    private List<UserProfileDto> topWriters = new ArrayList<>();
+    private final LatestWriterList<UserProfileDto> latestWriters = new LatestWriterList<>(RECENT_USER_MAX_COUNT);
+    private List<UserProfileDto> topWriters = new CopyOnWriteArrayList<>();
 
-    private long feedCountUntilUpdate;
-    private long feedWriterCountUntilUpdate;
+    private final AtomicLong feedCountUntilUpdate = new AtomicLong(0);
+    private final AtomicLong feedWriterCountUntilUpdate = new AtomicLong(0);
 
     @Override
     public void onApplicationEvent(@NotNull ApplicationStartedEvent event) {
@@ -68,7 +71,7 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
     }
 
     private void updateLatestWriters() {
-        latestWriters = new LinkedList<>(userRepository.findLatestUsers(PageRequest.of(0, 100)));
+        latestWriters.replaceAll(userRepository.findLatestUsers(PageRequest.of(0, 100)));
     }
 
     private void updateTopWriters() {
@@ -78,43 +81,40 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
         // 현재 최다 피드 사용자는 탑 10 명으로 순서는 따로 매기지 않는다.
         topWriters = userService.findByFeedCountTopUsers(to, from).stream()
                         .map(UserProfileDto::from)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toCollection(CopyOnWriteArrayList::new));
     }
 
     private void updateCounts() {
-        this.feedCountUntilUpdate = feedRepository.count();
-        this.feedWriterCountUntilUpdate = userRepository.writerCount();
-        this.todayFeedCount = 0;
+        this.feedCountUntilUpdate.set(feedRepository.count());
+        this.feedWriterCountUntilUpdate.set(userRepository.writerCount());
+        this.todayFeedCount.set(0);
     }
 
     public void addRecentUser(User user) {
         UserProfileDto dto = UserProfileDto.from(user);
-        if (!latestWriters.remove(dto) && latestWriters.size() > MAX_COUNT) {
-            latestWriters.removeFirst();
-        }
 
         latestWriters.add(dto);
-        todayFeedCount++;
+        todayFeedCount.incrementAndGet();
     }
 
     public void removeRecentUser(User user) {
-        todayFeedCount--;
         latestWriters.remove(UserProfileDto.from(user));
+        todayFeedCount.decrementAndGet();
     }
 
     public Long getTotalFeed() {
-        return this.feedCountUntilUpdate + todayFeedCount;
+        return this.feedCountUntilUpdate.get() + todayFeedCount.get();
     }
 
-    public Deque<UserProfileDto> getLatestWriters() {
-        return this.latestWriters;
+    public List<UserProfileDto> getLatestWriters() {
+        return this.latestWriters.getList();
     }
 
     public StatisticsDto.TotalContainer totalContainer() {
         return StatisticsDto.TotalContainer.builder()
-                .feedCount(feedCountUntilUpdate)
-                .writerCount(feedWriterCountUntilUpdate)
-                .latestWriters(latestWriters)
+                .feedCount(feedCountUntilUpdate.get())
+                .writerCount(feedWriterCountUntilUpdate.get())
+                .latestWriters(latestWriters.getList())
                 .topWriters(topWriters)
                 .build();
     }

--- a/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
@@ -98,10 +98,7 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
     public void updateRecentUser(User user) {
         UserProfileDto dto = UserProfileDto.from(user);
 
-        boolean updated = latestWriters.update(dto);
-        if (!updated) {
-            addRecentUser(user);
-        }
+        latestWriters.update(dto);
     }
 
     public void removeRecentUser(User user) {

--- a/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
@@ -32,7 +32,7 @@ import static org.springframework.data.domain.Pageable.unpaged;
 @Service
 @Log4j2
 public class StatisticsService implements ApplicationListener<ApplicationStartedEvent> {
-    public static final int RECENT_USER_MAX_COUNT = 100;
+    public static final int RECENT_WRITER_MAX_COUNT = 100;
     private final RestaurantService restaurantService;
     private final RecommendFeedService recommendFeedService;
 
@@ -41,7 +41,7 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
 
     private final AtomicInteger todayFeedCount = new AtomicInteger(0);
 
-    private final LatestWriterList<UserProfileDto> latestWriters = new LatestWriterList<>(RECENT_USER_MAX_COUNT);
+    private final LatestWriterList<UserProfileDto> latestWriters = new LatestWriterList<>(RECENT_WRITER_MAX_COUNT);
     private List<UserProfileDto> topWriters = new CopyOnWriteArrayList<>();
 
     private final AtomicLong feedCountUntilUpdate = new AtomicLong(0);

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -4,6 +4,7 @@ import container.restaurant.server.config.auth.user.CustomOAuth2User;
 import container.restaurant.server.domain.feed.hit.FeedHitRepository;
 import container.restaurant.server.domain.feed.picture.ImageService;
 import container.restaurant.server.domain.restaurant.favorite.RestaurantFavoriteRepository;
+import container.restaurant.server.domain.statistics.StatisticsService;
 import container.restaurant.server.domain.user.level.UserLevelFeedCountRepository;
 import container.restaurant.server.exception.ResourceNotFoundException;
 import container.restaurant.server.process.oauth.OAuthAgentService;
@@ -25,16 +26,14 @@ import static java.util.Optional.ofNullable;
 public class UserService {
 
     private final UserRepository userRepository;
-
-    private final ImageService imageService;
-
-    private final OAuthAgentService oAuthAgentService;
-
-    private final JwtLoginService jwtLoginService;
-
+    private final FeedHitRepository feedHitRepository;
     private final RestaurantFavoriteRepository restaurantFavoriteRepository;
     private final UserLevelFeedCountRepository userLevelFeedCountRepository;
-    private final FeedHitRepository feedHitRepository;
+
+    private final ImageService imageService;
+    private final JwtLoginService jwtLoginService;
+    private final OAuthAgentService oAuthAgentService;
+    private final StatisticsService statisticsService;
 
     @Transactional
     public User createOrUpdate(
@@ -78,6 +77,8 @@ public class UserService {
                 .ifPresent(user::setProfile);
         ofNullable(dto.getPushToken())
                 .ifPresent(user::setPushToken);
+
+        statisticsService.updateRecentUser(user);
         return UserDto.Info.from(user);
     }
 

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -71,7 +71,7 @@ class StatisticsServiceTest {
     @DisplayName("LatestWriter 리스트는 정해진 크기를 넘으면 가장 오래된 값을 제거한다")
     void deleteFirstWhenFull() {
         // Add user under max count
-        for (int i = 0; i < StatisticsService.RECENT_USER_MAX_COUNT; i++) {
+        for (int i = 0; i < StatisticsService.RECENT_WRITER_MAX_COUNT; i++) {
             User mockUser = createMockUser(i);
             statisticsService.addRecentUser(mockUser);
 
@@ -92,7 +92,7 @@ class StatisticsServiceTest {
             Long actualOldestWriterId = latestWriters.get(0).getId();
 
             assertThat(actualOldestWriterId).isEqualTo(expectOldestWriterId);
-            assertThat(latestWriters.size()).isEqualTo(StatisticsService.RECENT_USER_MAX_COUNT);
+            assertThat(latestWriters.size()).isEqualTo(StatisticsService.RECENT_WRITER_MAX_COUNT);
         }
     }
 

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -1,0 +1,56 @@
+package container.restaurant.server.domain.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import container.restaurant.server.domain.user.User;
+import container.restaurant.server.web.dto.statistics.UserProfileDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceTest {
+
+    @InjectMocks
+    StatisticsService statisticsService;
+
+    @Test
+    @DisplayName("LatestWriter 리스트는 정해진 크기를 넘으면 가장 오래된 값을 제거한다")
+    void deleteFirstWhenFull() {
+        // Add user under max count
+        for (int i = 0; i < StatisticsService.RECENT_USER_MAX_COUNT; i++) {
+            User mockUser = createMockUser(i);
+            statisticsService.addRecentUser(mockUser);
+
+            long oldestWriterId = statisticsService.getLatestWriters().get(0).getId();
+
+            assertThat(oldestWriterId).isZero();
+        }
+
+        // Check eviction when max count exceeded
+        int testLoopCount = 5;
+        for (int i = 0; i < testLoopCount; i++) {
+            User mockUser = createMockUser(i);
+            statisticsService.addRecentUser(mockUser);
+
+            List<UserProfileDto> latestWriters = statisticsService.getLatestWriters();
+
+            long expectOldestWriterId = i + 1;
+            Long actualOldestWriterId = latestWriters.get(0).getId();
+
+            assertThat(actualOldestWriterId).isEqualTo(expectOldestWriterId);
+            assertThat(latestWriters.size()).isEqualTo(StatisticsService.RECENT_USER_MAX_COUNT);
+        }
+    }
+
+    private User createMockUser(long id) {
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(id);
+        return mockUser;
+    }
+}

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -3,21 +3,69 @@ package container.restaurant.server.domain.statistics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
 import container.restaurant.server.domain.user.User;
+import container.restaurant.server.domain.user.UserRepository;
+import container.restaurant.server.domain.user.UserService;
 import container.restaurant.server.web.dto.statistics.UserProfileDto;
+import container.restaurant.server.web.dto.user.UserDto.Info;
+import container.restaurant.server.web.dto.user.UserDto.Update;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 class StatisticsServiceTest {
 
-    @InjectMocks
+    @Autowired
     StatisticsService statisticsService;
+
+    @Autowired
+    UserService userService;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저 정보가 수정되면 통계에도 반영된다")
+    void changeUserInfoInStatisticsWhenUserUpdate() {
+        final long userIdForUpdate = 1L;
+        final String beforeUpdateNickname = "nickname";
+        final String afterUpdateNickname = "changed-nickname";
+
+        final User userForUpdate = User.builder()
+                .nickname(beforeUpdateNickname)
+                .build();
+
+        // Add user to statistics
+        statisticsService.addRecentUser(userForUpdate);
+
+        Collection<UserProfileDto> latestWriters = statisticsService.totalContainer().getLatestWriters();
+        assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isTrue();
+        assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isFalse();
+
+        // Update user
+        when(userRepository.findById(userIdForUpdate)).thenReturn(Optional.of(userForUpdate));
+        Info update = userService.update(userIdForUpdate, Update.builder().nickname(afterUpdateNickname).build());
+
+        assertThat(update.getNickname()).isNotEqualTo(beforeUpdateNickname);
+        assertThat(update.getNickname()).isEqualTo(afterUpdateNickname);
+
+        // Check user info in statistics
+        latestWriters = statisticsService.totalContainer().getLatestWriters();
+
+        assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isFalse();
+        assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isTrue();
+
+    }
 
     @Test
     @DisplayName("LatestWriter 리스트는 정해진 크기를 넘으면 가장 오래된 값을 제거한다")
@@ -46,6 +94,15 @@ class StatisticsServiceTest {
             assertThat(actualOldestWriterId).isEqualTo(expectOldestWriterId);
             assertThat(latestWriters.size()).isEqualTo(StatisticsService.RECENT_USER_MAX_COUNT);
         }
+    }
+
+    private boolean containsUserWithNickname(Collection<UserProfileDto> users, String nickName) {
+        for (UserProfileDto user : users) {
+            if (user.getNickname().equals(nickName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private User createMockUser(long id) {


### PR DESCRIPTION
### 유저정보 업데이트 시 통계(모두의 용기)의 유저정보에도 반영되도록 수정

58d6960, 5844882

- LatestWriter 업데이트 메소드 추가
- UserService.update 시 LatestWriter 업데이트 메소드 호출
- 순환참조 이슈로 UserService 대신 UserRepository 사용
- 테스트 작성 및 간단한 리팩토링

### 공유 변수 thread-safe 한 구조로 변경

242d665

- 최근 작성자 리스트를 위한 LatestWriterList 추가
- latestWriters 간편한 수정을 위해 Deque 대신 List 사용
- latestWriters: Collections.synchronizedList
- topWriters: CopyOnWriteArrayList
- feedCount 류: AtomicXXX

### latestWriter 리스트 최대크기 초과 시 오래된 사용자 제거 테스트 추가

5d209ca

Closes #161 