### PR TITLE
총 피드 수, 총 피드 작성자 수 실시간 업데이트, 변수와 함수 이름을 더 명확하게 변경

### DIFF
--- a/src/main/java/container/restaurant/server/domain/feed/FeedService.java
+++ b/src/main/java/container/restaurant/server/domain/feed/FeedService.java
@@ -134,8 +134,6 @@ public class FeedService {
         if (!feed.getOwner().getId().equals(userId))
             throw new FailedAuthorizationException("해당 피드를 삭제할 수 없습니다.");
 
-        statisticsService.removeRecentUser(feed.getOwner());
-
         feed.getOwner().feedCountDown();
         feed.getRestaurant().deleteFeedStatics(feed);
         feedHitRepository.deleteAllByFeed(feed);
@@ -163,6 +161,7 @@ public class FeedService {
         feedRepository.delete(feed);
 
         recommendFeedService.checkAndDelete(feed);
+        statisticsService.afterFeedDelete(feed.getOwner());
     }
 
     @Transactional
@@ -176,7 +175,7 @@ public class FeedService {
         user.feedCountUp();
         restaurant.updateFeedStatics(feed);
 
-        statisticsService.addRecentUser(user);
+        statisticsService.afterFeedCreate(user);
 
         LevelUpDto levelUpDto = userLevelFeedCountService.levelFeedUp(feed);
         return new FeedCreateResultDto(feed.getId(), levelUpDto);

--- a/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
@@ -113,6 +113,10 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
         return totalFeedCount.get();
     }
 
+    public Long getTotalFeedWriterCount() {
+        return totalFeedWriterCount.get();
+    }
+
     public List<UserProfileDto> getLatestWriters() {
         return this.latestWriters.getList();
     }

--- a/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
+++ b/src/main/java/container/restaurant/server/domain/statistics/StatisticsService.java
@@ -117,7 +117,7 @@ public class StatisticsService implements ApplicationListener<ApplicationStarted
         return this.latestWriters.getList();
     }
 
-    public StatisticsDto.TotalContainer totalStatistics() {
+    public StatisticsDto.TotalContainer totalContainer() {
         return StatisticsDto.TotalContainer.builder()
                 .feedCount(totalFeedCount.get())
                 .writerCount(totalFeedWriterCount.get())

--- a/src/main/java/container/restaurant/server/domain/user/UserService.java
+++ b/src/main/java/container/restaurant/server/domain/user/UserService.java
@@ -78,7 +78,7 @@ public class UserService {
         ofNullable(dto.getPushToken())
                 .ifPresent(user::setPushToken);
 
-        statisticsService.updateRecentUser(user);
+        statisticsService.afterUserUpdate(user);
         return UserDto.Info.from(user);
     }
 

--- a/src/main/java/container/restaurant/server/web/HomeController.java
+++ b/src/main/java/container/restaurant/server/web/HomeController.java
@@ -43,7 +43,7 @@ public class HomeController {
         return ResponseEntity.ok(
                 setLinks(HomeDto.builder()
                         .user(loginUser)
-                        .totalContainer(statisticsService.getTotalFeed())
+                        .totalContainer(statisticsService.getTotalFeedCount())
                         .phrase(phraseService.getPhrase())
                         .latestWriters(statisticsService.getLatestWriters())
                         .banners(bannerRepository.findAllHomeBanner())

--- a/src/main/java/container/restaurant/server/web/StatisticsController.java
+++ b/src/main/java/container/restaurant/server/web/StatisticsController.java
@@ -18,7 +18,7 @@ public class StatisticsController {
 
     @GetMapping("/total-container")
     public ResponseEntity<?> getFeedStatistics() {
-        return ResponseEntity.ok(statisticsService.totalStatistics());
+        return ResponseEntity.ok(statisticsService.totalContainer());
     }
 
     @Secured("ROLE_TEST")

--- a/src/main/java/container/restaurant/server/web/StatisticsController.java
+++ b/src/main/java/container/restaurant/server/web/StatisticsController.java
@@ -4,7 +4,6 @@ import container.restaurant.server.domain.statistics.StatisticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +18,7 @@ public class StatisticsController {
 
     @GetMapping("/total-container")
     public ResponseEntity<?> getFeedStatistics() {
-        return ResponseEntity.ok(statisticsService.totalContainer());
+        return ResponseEntity.ok(statisticsService.totalStatistics());
     }
 
     @Secured("ROLE_TEST")

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -48,7 +48,7 @@ class StatisticsServiceTest {
         // Add user to statistics
         statisticsService.afterFeedCreate(userForUpdate);
 
-        Collection<UserProfileDto> latestWriters = statisticsService.totalStatistics().getLatestWriters();
+        Collection<UserProfileDto> latestWriters = statisticsService.totalContainer().getLatestWriters();
         assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isTrue();
         assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isFalse();
 
@@ -60,7 +60,7 @@ class StatisticsServiceTest {
         assertThat(update.getNickname()).isEqualTo(afterUpdateNickname);
 
         // Check user info in statistics
-        latestWriters = statisticsService.totalStatistics().getLatestWriters();
+        latestWriters = statisticsService.totalContainer().getLatestWriters();
 
         assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isFalse();
         assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isTrue();

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -46,9 +46,9 @@ class StatisticsServiceTest {
                 .build();
 
         // Add user to statistics
-        statisticsService.addRecentUser(userForUpdate);
+        statisticsService.afterFeedCreate(userForUpdate);
 
-        Collection<UserProfileDto> latestWriters = statisticsService.totalContainer().getLatestWriters();
+        Collection<UserProfileDto> latestWriters = statisticsService.totalStatistics().getLatestWriters();
         assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isTrue();
         assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isFalse();
 
@@ -60,7 +60,7 @@ class StatisticsServiceTest {
         assertThat(update.getNickname()).isEqualTo(afterUpdateNickname);
 
         // Check user info in statistics
-        latestWriters = statisticsService.totalContainer().getLatestWriters();
+        latestWriters = statisticsService.totalStatistics().getLatestWriters();
 
         assertThat(containsUserWithNickname(latestWriters, beforeUpdateNickname)).isFalse();
         assertThat(containsUserWithNickname(latestWriters, afterUpdateNickname)).isTrue();
@@ -73,7 +73,7 @@ class StatisticsServiceTest {
         // Add user under max count
         for (int i = 0; i < StatisticsService.RECENT_WRITER_MAX_COUNT; i++) {
             User mockUser = createMockUser(i);
-            statisticsService.addRecentUser(mockUser);
+            statisticsService.afterFeedCreate(mockUser);
 
             long oldestWriterId = statisticsService.getLatestWriters().get(0).getId();
 
@@ -84,7 +84,7 @@ class StatisticsServiceTest {
         int testLoopCount = 5;
         for (int i = 0; i < testLoopCount; i++) {
             User mockUser = createMockUser(i);
-            statisticsService.addRecentUser(mockUser);
+            statisticsService.afterFeedCreate(mockUser);
 
             List<UserProfileDto> latestWriters = statisticsService.getLatestWriters();
 

--- a/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
+++ b/src/test/java/container/restaurant/server/domain/statistics/StatisticsServiceTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 import container.restaurant.server.domain.user.User;
 import container.restaurant.server.domain.user.UserRepository;
 import container.restaurant.server.domain.user.UserService;
+import container.restaurant.server.web.dto.statistics.StatisticsDto.TotalContainer;
 import container.restaurant.server.web.dto.statistics.UserProfileDto;
 import container.restaurant.server.web.dto.user.UserDto.Info;
 import container.restaurant.server.web.dto.user.UserDto.Update;
@@ -94,6 +95,61 @@ class StatisticsServiceTest {
             assertThat(actualOldestWriterId).isEqualTo(expectOldestWriterId);
             assertThat(latestWriters.size()).isEqualTo(StatisticsService.RECENT_WRITER_MAX_COUNT);
         }
+    }
+
+    @Test
+    @DisplayName("총 피드 수, 총 피드 작성자 수 테스트")
+    void updateFeedCountRealtime() {
+        TotalContainer totalContainer = statisticsService.totalContainer();
+
+        assertThat(totalContainer.getWriterCount()).isZero();
+        assertThat(totalContainer.getFeedCount()).isZero();
+
+        User mockUser1 = createMockUser(1L);
+        User mockUser2 = createMockUser(2L);
+
+        int mockUser1FeedCount = 0;
+        int mockUser2FeedCount = 0;
+
+        // user1 피드 1개 작성, user2 피드 2개 작성
+        when(mockUser1.getFeedCount()).thenReturn(++mockUser1FeedCount);
+        statisticsService.afterFeedCreate(mockUser1);
+        when(mockUser2.getFeedCount()).thenReturn(++mockUser2FeedCount);
+        statisticsService.afterFeedCreate(mockUser2);
+        when(mockUser2.getFeedCount()).thenReturn(++mockUser2FeedCount);
+        statisticsService.afterFeedCreate(mockUser2);
+
+        totalContainer = statisticsService.totalContainer();
+
+        assertThat(totalContainer.getWriterCount()).isEqualTo(2);
+        assertThat(totalContainer.getFeedCount()).isEqualTo(3);
+
+        // user2 자신 피드 2개 중 1개 삭제
+        when(mockUser2.getFeedCount()).thenReturn(--mockUser2FeedCount);
+        statisticsService.afterFeedDelete(mockUser2);
+
+        totalContainer = statisticsService.totalContainer();
+
+        assertThat(totalContainer.getWriterCount()).isEqualTo(2);
+        assertThat(totalContainer.getFeedCount()).isEqualTo(2);
+
+        // user2 하나 남은 피드 삭제
+        when(mockUser2.getFeedCount()).thenReturn(--mockUser2FeedCount);
+        statisticsService.afterFeedDelete(mockUser2);
+
+        totalContainer = statisticsService.totalContainer();
+
+        assertThat(totalContainer.getWriterCount()).isEqualTo(1);
+        assertThat(totalContainer.getFeedCount()).isEqualTo(1);
+
+        // user1 하나 남은 피드 삭제
+        when(mockUser1.getFeedCount()).thenReturn(--mockUser1FeedCount);
+        statisticsService.afterFeedDelete(mockUser1);
+
+        totalContainer = statisticsService.totalContainer();
+
+        assertThat(totalContainer.getWriterCount()).isZero();
+        assertThat(totalContainer.getFeedCount()).isZero();
     }
 
     private boolean containsUserWithNickname(Collection<UserProfileDto> users, String nickName) {

--- a/src/test/java/container/restaurant/server/web/HomeControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/HomeControllerTest.java
@@ -44,8 +44,8 @@ class HomeControllerTest extends BaseUserControllerTest {
         bannerRepository.save(new Banner("title2", "banner2", "content2", "additional2"));
         bannerRepository.save(new Banner("title3", "banner3", "content3", "additional3"));
 
-        statisticsService.addRecentUser(myself);
-        statisticsService.addRecentUser(other);
+        statisticsService.afterFeedCreate(myself);
+        statisticsService.afterFeedCreate(other);
     }
 
     @Test


### PR DESCRIPTION
ba051576077f6daac030f09629c4af8d5aa834b8 커밋을 좀 잘게 나눴어야 했는데 이것저것 섞였네요 😅

---

### 최근 피드 작성자 버그 수정

**버그 발견**
1. 유저 한명이 피드를 2개 작성
2. 피드 1개만 삭제
3. 피드 1개 남았지만 최근 피드 작성자 목록에서 제거

**버그 수정**
- `feedCount` 가 `0`인 경우에만 목록에서 제거 
- 아직 이런경우가 잘 없고 자정에는 업데이트 돼서 발견 못하지 않았을까 싶네요 😅

---

### 총 피드 수, 총 피드 작성자 수 실시간 업데이트

추후에 이런 후처리 과정들은 바로 서비스 함수를 호출하지 않고 PushFeedEventHandler 처럼 독립적으로 처리하는건 어떨까 싶네요!

```
// ! 대충 구상해본 그림
public deleteUser() {
    ...
    publisher.userDelete(params)
}

@EventListener
public void onUserDelete(params) {
    feedService.deleteFeedsByUser()
    statisticsService.removeLatestWriters()
    ....
}
```

- 용도가 애매한 `todayFeedCount` 제거
- `feed*UntilUpdate` 대신 실시간으로 업데이트하는 `totalFeedCount`, `totalFeedWriterCount` 추가
- `FeedService.delete()`에 피드 수, 피드 작성자 수 업데이트하는 함수 추가
- 테스트는 조금 이상하지만 나중에 개선해볼게요ㅠ

---

### 네이밍 변경

- `removeRecentUser` 와 같은 네이밍을 `afterFeedDelete` 로 변경
    - 이름은 `removeRecentUser` 지만 `feedCount` 도 수정 하고 있음