### PR TITLE
[feature-46] 푸시 토큰 요청은 비로그인 허용, api path 명확하게 수정

### DIFF
--- a/src/main/java/container/restaurant/server/config/auth/SecurityConfig.java
+++ b/src/main/java/container/restaurant/server/config/auth/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests(a -> a
                         .antMatchers(GET).permitAll()
                         .antMatchers(POST, "/api/user/login", "/api/user").permitAll()
-                        .antMatchers(POST, "/api/push").permitAll() // 비 로그인 사용자 push token 저장 허용
+                        .antMatchers( "/api/push/token/*").permitAll() // 비 로그인 사용자 push token 저장 허용
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtTokenFilter, OAuth2LoginAuthenticationFilter.class);
     }

--- a/src/main/java/container/restaurant/server/web/PushController.java
+++ b/src/main/java/container/restaurant/server/web/PushController.java
@@ -3,42 +3,19 @@ package container.restaurant.server.web;
 import container.restaurant.server.config.auth.LoginId;
 import container.restaurant.server.domain.push.PushToken;
 import container.restaurant.server.domain.push.PushTokenService;
-import container.restaurant.server.utils.FirebaseCloudMessageUtils;
 import container.restaurant.server.web.linker.PushTokenLinker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.mediatype.hal.HalModelBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
-
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/push")
 public class PushController {
 
-    final private FirebaseCloudMessageUtils firebaseCloudMessageUtils;
     final private PushTokenService pushTokenService;
     final private PushTokenLinker pushTokenLinker;
-
-    /*
-     * 푸시 테스트용 불필요시 삭제 예정
-     *
-     * @param token
-     * @return
-     * @throws IOException
-     */
-    @GetMapping(value = "{token}")
-    public ResponseEntity<?> pushSendTest(@PathVariable() String token) throws IOException {
-        PushToken pushToken = PushToken.builder().token(token).build();
-        firebaseCloudMessageUtils.sendMessage(pushToken, "용기낸 식당", "Push 알림 테스트 입니다.");
-        return ResponseEntity.ok(
-                HalModelBuilder.emptyHalModel().build()
-                        .add(linkTo(PushController.class).withSelfRel()));
-    }
 
     /*
      * [ 비로그인 허용 ]
@@ -50,7 +27,7 @@ public class PushController {
      * @param token
      * @return
      */
-    @PostMapping("{token}")
+    @PostMapping("/token/{token}")
     public ResponseEntity<?> registerClientPushToken(
             @LoginId Long loginId,
             @PathVariable String token) {
@@ -71,7 +48,7 @@ public class PushController {
      * @param sessionUser
      * @return
      */
-    @DeleteMapping("{tokenId}")
+    @DeleteMapping("/token/{tokenId}")
     public ResponseEntity<?> deleteClientPushToken(
             @LoginId Long loginId,
             @PathVariable Long tokenId) {

--- a/src/main/java/container/restaurant/server/web/PushController.java
+++ b/src/main/java/container/restaurant/server/web/PushController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/push")
 public class PushController {
 
-    final private PushTokenService pushTokenService;
-    final private PushTokenLinker pushTokenLinker;
+    private final PushTokenService pushTokenService;
+    private final PushTokenLinker pushTokenLinker;
 
     /*
      * [ 비로그인 허용 ]

--- a/src/test/java/container/restaurant/server/web/PushControllerTest.java
+++ b/src/test/java/container/restaurant/server/web/PushControllerTest.java
@@ -23,7 +23,7 @@ class PushControllerTest extends BaseUserAndFeedControllerTest {
     void registerClientPushToken() throws Exception {
         String testToken = "ASDFDWAQWERASDFZXCV1";
 
-        mvc.perform(post("/api/push/{token}", testToken))
+        mvc.perform(post("/api/push/token/{token}", testToken))
                 .andExpect(status().isOk())
                 .andDo(document("push-token-register"));
     }
@@ -34,7 +34,7 @@ class PushControllerTest extends BaseUserAndFeedControllerTest {
         String testToken = "ASDFDWAQWERASDFZXCV2";
         Long id = pushTokenService.registerPushToken(testToken).getId();
 
-        mvc.perform(delete("/api/push/{tokenId}", id))
+        mvc.perform(delete("/api/push/token/{tokenId}", id))
                 .andExpect(status().isNoContent())
                 .andDo(document("push-token-delete"));
     }


### PR DESCRIPTION
### API path 명확하게 변경
API path 변경을 제안하고싶어 클라이언트 분들도 리뷰요청 드렸습니다. (범순님 깃헙 아이디가 뭔가요?? 😅 )

||추가|삭제|
|-|-|-|
|AS-IS|`POST /api/push/{token}`| `DELETE /api/push/{tokenId}`|
|TO-BE|`POST /api/push/token/{token}`|`DELETE /api/push/token/{tokenId}`|

변경해도 괜찮을까요?

### 푸시 토큰 요청 비로그인 허용
`.antMatchers( "/api/push/token/*").permitAll()`